### PR TITLE
Add `"main"` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "line-awesome",
   "version": "1.2.1",
   "description": "Line Awesome by Icon8. A drop-in replacement for Font Awesome.",
-  "license": "MIT",
   "keywords": [
     "font",
     "awesome",
@@ -14,5 +13,7 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/icons8/line-awesome.git"
-  }
+  },
+  "license": "MIT",
+  "main": "dist/line-awesome/css/line-awesome.css"
 }


### PR DESCRIPTION
This allows tools like [`postcss-import`](https://github.com/postcss/postcss-import#postcss-import) to automatically resolve `@import` statements from `.css` files.

```css
/* Currently not possible */
@import 'line-awesome';
```