### PR TITLE
Added basic search term metadata file for issue #45

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -1,0 +1,17172 @@
+{
+    "500px": {
+        "character": "\uf26e",
+        "searchterms": [
+            "500px"
+        ]
+    },
+    "accessible-icon": {
+        "character": "\uf368",
+        "searchterms": [
+            "accessibility",
+            "handicap",
+            "person",
+            "wheelchair",
+            "wheelchair-alt",
+            "accessible-icon"
+        ]
+    },
+    "accusoft": {
+        "character": "\uf369",
+        "searchterms": [
+            "accusoft"
+        ]
+    },
+    "acquisitions-incorporated": {
+        "character": "\uf6af",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "game",
+            "gaming",
+            "tabletop",
+            "acquisitions-incorporated"
+        ]
+    },
+    "ad": {
+        "character": "\uf641",
+        "searchterms": [
+            "advertisement",
+            "media",
+            "newspaper",
+            "promotion",
+            "publicity",
+            "ad"
+        ]
+    },
+    "address-book": {
+        "character": "\uf2b9",
+        "searchterms": [
+            "contact",
+            "directory",
+            "index",
+            "little black book",
+            "rolodex",
+            "address-book",
+            "address-book-o"
+        ]
+    },
+    "address-book-o": {
+        "character": "\uf2b9",
+        "searchterms": [
+            "contact",
+            "directory",
+            "index",
+            "little black book",
+            "rolodex",
+            "address-book",
+            "address-book-o"
+        ]
+    },
+    "address-card": {
+        "character": "\uf2bb",
+        "searchterms": [
+            "about",
+            "contact",
+            "id",
+            "identification",
+            "postcard",
+            "profile",
+            "address-card",
+            "vcard",
+            "address-card-o",
+            "vcard-o"
+        ]
+    },
+    "address-card-o": {
+        "character": "\uf2bb",
+        "searchterms": [
+            "about",
+            "contact",
+            "id",
+            "identification",
+            "postcard",
+            "profile",
+            "address-card",
+            "vcard",
+            "address-card-o",
+            "vcard-o"
+        ]
+    },
+    "adjust": {
+        "character": "\uf042",
+        "searchterms": [
+            "contrast",
+            "dark",
+            "light",
+            "saturation",
+            "adjust"
+        ]
+    },
+    "adn": {
+        "character": "\uf170",
+        "searchterms": [
+            "adn"
+        ]
+    },
+    "adobe": {
+        "character": "\uf778",
+        "searchterms": [
+            "acrobat",
+            "app",
+            "design",
+            "illustrator",
+            "indesign",
+            "photoshop",
+            "adobe"
+        ]
+    },
+    "adversal": {
+        "character": "\uf36a",
+        "searchterms": [
+            "adversal"
+        ]
+    },
+    "affiliatetheme": {
+        "character": "\uf36b",
+        "searchterms": [
+            "affiliatetheme"
+        ]
+    },
+    "air-freshener": {
+        "character": "\uf5d0",
+        "searchterms": [
+            "car",
+            "deodorize",
+            "fresh",
+            "pine",
+            "scent",
+            "air-freshener"
+        ]
+    },
+    "airbnb": {
+        "character": "\uf834",
+        "searchterms": [
+            "airbnb"
+        ]
+    },
+    "algolia": {
+        "character": "\uf36c",
+        "searchterms": [
+            "algolia"
+        ]
+    },
+    "align-center": {
+        "character": "\uf037",
+        "searchterms": [
+            "format",
+            "middle",
+            "paragraph",
+            "text",
+            "align-center"
+        ]
+    },
+    "align-justify": {
+        "character": "\uf039",
+        "searchterms": [
+            "format",
+            "paragraph",
+            "text",
+            "align-justify"
+        ]
+    },
+    "align-left": {
+        "character": "\uf036",
+        "searchterms": [
+            "format",
+            "paragraph",
+            "text",
+            "align-left"
+        ]
+    },
+    "align-right": {
+        "character": "\uf038",
+        "searchterms": [
+            "format",
+            "paragraph",
+            "text",
+            "align-right"
+        ]
+    },
+    "alipay": {
+        "character": "\uf642",
+        "searchterms": [
+            "alipay"
+        ]
+    },
+    "allergies": {
+        "character": "\uf461",
+        "searchterms": [
+            "allergy",
+            "freckles",
+            "hand",
+            "hives",
+            "pox",
+            "skin",
+            "spots",
+            "allergies"
+        ]
+    },
+    "amazon": {
+        "character": "\uf270",
+        "searchterms": [
+            "amazon"
+        ]
+    },
+    "amazon-pay": {
+        "character": "\uf42c",
+        "searchterms": [
+            "amazon-pay"
+        ]
+    },
+    "ambulance": {
+        "character": "\uf0f9",
+        "searchterms": [
+            "covid-19",
+            "emergency",
+            "emt",
+            "er",
+            "help",
+            "hospital",
+            "support",
+            "vehicle",
+            "ambulance"
+        ]
+    },
+    "american-sign-language-interpreting": {
+        "character": "\uf2a3",
+        "searchterms": [
+            "asl",
+            "deaf",
+            "finger",
+            "hand",
+            "interpret",
+            "speak",
+            "american-sign-language-interpreting",
+            "asl-interpreting"
+        ]
+    },
+    "amilia": {
+        "character": "\uf36d",
+        "searchterms": [
+            "amilia"
+        ]
+    },
+    "anchor": {
+        "character": "\uf13d",
+        "searchterms": [
+            "berth",
+            "boat",
+            "dock",
+            "embed",
+            "link",
+            "maritime",
+            "moor",
+            "secure",
+            "anchor"
+        ]
+    },
+    "android": {
+        "character": "\uf17b",
+        "searchterms": [
+            "robot",
+            "android"
+        ]
+    },
+    "angellist": {
+        "character": "\uf209",
+        "searchterms": [
+            "angellist"
+        ]
+    },
+    "angle-double-down": {
+        "character": "\uf103",
+        "searchterms": [
+            "arrows",
+            "caret",
+            "download",
+            "expand",
+            "angle-double-down"
+        ]
+    },
+    "angle-double-left": {
+        "character": "\uf100",
+        "searchterms": [
+            "arrows",
+            "back",
+            "caret",
+            "laquo",
+            "previous",
+            "quote",
+            "angle-double-left"
+        ]
+    },
+    "angle-double-right": {
+        "character": "\uf101",
+        "searchterms": [
+            "arrows",
+            "caret",
+            "forward",
+            "more",
+            "next",
+            "quote",
+            "raquo",
+            "angle-double-right"
+        ]
+    },
+    "angle-double-up": {
+        "character": "\uf102",
+        "searchterms": [
+            "arrows",
+            "caret",
+            "collapse",
+            "upload",
+            "angle-double-up"
+        ]
+    },
+    "angle-down": {
+        "character": "\uf107",
+        "searchterms": [
+            "arrow",
+            "caret",
+            "download",
+            "expand",
+            "angle-down"
+        ]
+    },
+    "angle-left": {
+        "character": "\uf104",
+        "searchterms": [
+            "arrow",
+            "back",
+            "caret",
+            "less",
+            "previous",
+            "angle-left"
+        ]
+    },
+    "angle-right": {
+        "character": "\uf105",
+        "searchterms": [
+            "arrow",
+            "care",
+            "forward",
+            "more",
+            "next",
+            "angle-right"
+        ]
+    },
+    "angle-up": {
+        "character": "\uf106",
+        "searchterms": [
+            "arrow",
+            "caret",
+            "collapse",
+            "upload",
+            "angle-up"
+        ]
+    },
+    "angry": {
+        "character": "\uf556",
+        "searchterms": [
+            "disapprove",
+            "emoticon",
+            "face",
+            "mad",
+            "upset",
+            "angry"
+        ]
+    },
+    "angrycreative": {
+        "character": "\uf36e",
+        "searchterms": [
+            "angrycreative"
+        ]
+    },
+    "angular": {
+        "character": "\uf420",
+        "searchterms": [
+            "angular"
+        ]
+    },
+    "ankh": {
+        "character": "\uf644",
+        "searchterms": [
+            "amulet",
+            "copper",
+            "coptic christianity",
+            "copts",
+            "crux ansata",
+            "egypt",
+            "venus",
+            "ankh"
+        ]
+    },
+    "app-store": {
+        "character": "\uf36f",
+        "searchterms": [
+            "app-store"
+        ]
+    },
+    "app-store-ios": {
+        "character": "\uf370",
+        "searchterms": [
+            "app-store-ios"
+        ]
+    },
+    "apper": {
+        "character": "\uf371",
+        "searchterms": [
+            "apper"
+        ]
+    },
+    "apple": {
+        "character": "\uf179",
+        "searchterms": [
+            "fruit",
+            "ios",
+            "mac",
+            "operating system",
+            "os",
+            "osx",
+            "apple"
+        ]
+    },
+    "apple-alt": {
+        "character": "\uf5d1",
+        "searchterms": [
+            "fall",
+            "fruit",
+            "fuji",
+            "macintosh",
+            "orchard",
+            "seasonal",
+            "vegan",
+            "apple-alt"
+        ]
+    },
+    "apple-pay": {
+        "character": "\uf415",
+        "searchterms": [
+            "apple-pay"
+        ]
+    },
+    "archive": {
+        "character": "\uf187",
+        "searchterms": [
+            "box",
+            "package",
+            "save",
+            "storage",
+            "archive"
+        ]
+    },
+    "archway": {
+        "character": "\uf557",
+        "searchterms": [
+            "arc",
+            "monument",
+            "road",
+            "street",
+            "tunnel",
+            "archway"
+        ]
+    },
+    "area-chart": {
+        "character": "\uf1fe",
+        "searchterms": [
+            "analytics",
+            "area",
+            "chart",
+            "graph",
+            "chart-area",
+            "area-chart"
+        ]
+    },
+    "arrow-alt-circle-down": {
+        "character": "\uf358",
+        "searchterms": [
+            "arrow-circle-o-down",
+            "download",
+            "arrow-alt-circle-down"
+        ]
+    },
+    "arrow-alt-circle-left": {
+        "character": "\uf359",
+        "searchterms": [
+            "arrow-circle-o-left",
+            "back",
+            "previous",
+            "arrow-alt-circle-left"
+        ]
+    },
+    "arrow-alt-circle-right": {
+        "character": "\uf35a",
+        "searchterms": [
+            "arrow-circle-o-right",
+            "forward",
+            "next",
+            "arrow-alt-circle-right"
+        ]
+    },
+    "arrow-alt-circle-up": {
+        "character": "\uf35b",
+        "searchterms": [
+            "arrow-circle-o-up",
+            "arrow-alt-circle-up"
+        ]
+    },
+    "arrow-circle-down": {
+        "character": "\uf0ab",
+        "searchterms": [
+            "download",
+            "arrow-circle-down"
+        ]
+    },
+    "arrow-circle-left": {
+        "character": "\uf0a8",
+        "searchterms": [
+            "back",
+            "previous",
+            "arrow-circle-left"
+        ]
+    },
+    "arrow-circle-o-down": {
+        "character": "\uf358",
+        "searchterms": [
+            "arrow-circle-o-down",
+            "download",
+            "arrow-alt-circle-down"
+        ]
+    },
+    "arrow-circle-o-left": {
+        "character": "\uf359",
+        "searchterms": [
+            "arrow-circle-o-left",
+            "back",
+            "previous",
+            "arrow-alt-circle-left"
+        ]
+    },
+    "arrow-circle-o-right": {
+        "character": "\uf35a",
+        "searchterms": [
+            "arrow-circle-o-right",
+            "forward",
+            "next",
+            "arrow-alt-circle-right"
+        ]
+    },
+    "arrow-circle-o-up": {
+        "character": "\uf35b",
+        "searchterms": [
+            "arrow-circle-o-up",
+            "arrow-alt-circle-up"
+        ]
+    },
+    "arrow-circle-right": {
+        "character": "\uf0a9",
+        "searchterms": [
+            "forward",
+            "next",
+            "arrow-circle-right"
+        ]
+    },
+    "arrow-circle-up": {
+        "character": "\uf0aa",
+        "searchterms": [
+            "upload",
+            "arrow-circle-up"
+        ]
+    },
+    "arrow-down": {
+        "character": "\uf063",
+        "searchterms": [
+            "download",
+            "arrow-down"
+        ]
+    },
+    "arrow-left": {
+        "character": "\uf060",
+        "searchterms": [
+            "back",
+            "previous",
+            "arrow-left"
+        ]
+    },
+    "arrow-right": {
+        "character": "\uf061",
+        "searchterms": [
+            "forward",
+            "next",
+            "arrow-right"
+        ]
+    },
+    "arrow-up": {
+        "character": "\uf062",
+        "searchterms": [
+            "forward",
+            "upload",
+            "arrow-up"
+        ]
+    },
+    "arrows": {
+        "character": "\uf0b2",
+        "searchterms": [
+            "arrow",
+            "arrows",
+            "bigger",
+            "enlarge",
+            "expand",
+            "fullscreen",
+            "move",
+            "position",
+            "reorder",
+            "resize",
+            "arrows-alt"
+        ]
+    },
+    "arrows-alt": {
+        "character": "\uf0b2",
+        "searchterms": [
+            "arrow",
+            "arrows",
+            "bigger",
+            "enlarge",
+            "expand",
+            "fullscreen",
+            "move",
+            "position",
+            "reorder",
+            "resize",
+            "arrows-alt"
+        ]
+    },
+    "arrows-alt-h": {
+        "character": "\uf337",
+        "searchterms": [
+            "arrows-h",
+            "expand",
+            "horizontal",
+            "landscape",
+            "resize",
+            "wide",
+            "arrows-alt-h"
+        ]
+    },
+    "arrows-alt-v": {
+        "character": "\uf338",
+        "searchterms": [
+            "arrows-v",
+            "expand",
+            "portrait",
+            "resize",
+            "tall",
+            "vertical",
+            "arrows-alt-v"
+        ]
+    },
+    "arrows-h": {
+        "character": "\uf337",
+        "searchterms": [
+            "arrows-h",
+            "expand",
+            "horizontal",
+            "landscape",
+            "resize",
+            "wide",
+            "arrows-alt-h"
+        ]
+    },
+    "arrows-v": {
+        "character": "\uf338",
+        "searchterms": [
+            "arrows-v",
+            "expand",
+            "portrait",
+            "resize",
+            "tall",
+            "vertical",
+            "arrows-alt-v"
+        ]
+    },
+    "artstation": {
+        "character": "\uf77a",
+        "searchterms": [
+            "artstation"
+        ]
+    },
+    "asl-interpreting": {
+        "character": "\uf2a3",
+        "searchterms": [
+            "asl",
+            "deaf",
+            "finger",
+            "hand",
+            "interpret",
+            "speak",
+            "american-sign-language-interpreting",
+            "asl-interpreting"
+        ]
+    },
+    "assistive-listening-systems": {
+        "character": "\uf2a2",
+        "searchterms": [
+            "amplify",
+            "audio",
+            "deaf",
+            "ear",
+            "headset",
+            "hearing",
+            "sound",
+            "assistive-listening-systems"
+        ]
+    },
+    "asterisk": {
+        "character": "\uf069",
+        "searchterms": [
+            "annotation",
+            "details",
+            "reference",
+            "star",
+            "asterisk"
+        ]
+    },
+    "asymmetrik": {
+        "character": "\uf372",
+        "searchterms": [
+            "asymmetrik"
+        ]
+    },
+    "at": {
+        "character": "\uf1fa",
+        "searchterms": [
+            "address",
+            "author",
+            "e-mail",
+            "email",
+            "handle",
+            "at"
+        ]
+    },
+    "atlas": {
+        "character": "\uf558",
+        "searchterms": [
+            "book",
+            "directions",
+            "geography",
+            "globe",
+            "map",
+            "travel",
+            "wayfinding",
+            "atlas"
+        ]
+    },
+    "atlassian": {
+        "character": "\uf77b",
+        "searchterms": [
+            "atlassian"
+        ]
+    },
+    "atom": {
+        "character": "\uf5d2",
+        "searchterms": [
+            "atheism",
+            "chemistry",
+            "electron",
+            "ion",
+            "isotope",
+            "neutron",
+            "nuclear",
+            "proton",
+            "science",
+            "atom"
+        ]
+    },
+    "audible": {
+        "character": "\uf373",
+        "searchterms": [
+            "audible"
+        ]
+    },
+    "audio-description": {
+        "character": "\uf29e",
+        "searchterms": [
+            "blind",
+            "narration",
+            "video",
+            "visual",
+            "audio-description"
+        ]
+    },
+    "automobile": {
+        "character": "\uf1b9",
+        "searchterms": [
+            "auto",
+            "automobile",
+            "sedan",
+            "transportation",
+            "travel",
+            "vehicle",
+            "car"
+        ]
+    },
+    "autoprefixer": {
+        "character": "\uf41c",
+        "searchterms": [
+            "autoprefixer"
+        ]
+    },
+    "avianex": {
+        "character": "\uf374",
+        "searchterms": [
+            "avianex"
+        ]
+    },
+    "aviato": {
+        "character": "\uf421",
+        "searchterms": [
+            "aviato"
+        ]
+    },
+    "award": {
+        "character": "\uf559",
+        "searchterms": [
+            "honor",
+            "praise",
+            "prize",
+            "recognition",
+            "ribbon",
+            "trophy",
+            "award"
+        ]
+    },
+    "aws": {
+        "character": "\uf375",
+        "searchterms": [
+            "aws"
+        ]
+    },
+    "baby": {
+        "character": "\uf77c",
+        "searchterms": [
+            "child",
+            "diaper",
+            "doll",
+            "human",
+            "infant",
+            "kid",
+            "offspring",
+            "person",
+            "sprout",
+            "baby"
+        ]
+    },
+    "baby-carriage": {
+        "character": "\uf77d",
+        "searchterms": [
+            "buggy",
+            "carrier",
+            "infant",
+            "push",
+            "stroller",
+            "transportation",
+            "walk",
+            "wheels",
+            "baby-carriage"
+        ]
+    },
+    "backspace": {
+        "character": "\uf55a",
+        "searchterms": [
+            "command",
+            "delete",
+            "erase",
+            "keyboard",
+            "undo",
+            "backspace"
+        ]
+    },
+    "backward": {
+        "character": "\uf04a",
+        "searchterms": [
+            "previous",
+            "rewind",
+            "backward"
+        ]
+    },
+    "bacon": {
+        "character": "\uf7e5",
+        "searchterms": [
+            "blt",
+            "breakfast",
+            "ham",
+            "lard",
+            "meat",
+            "pancetta",
+            "pork",
+            "rasher",
+            "bacon"
+        ]
+    },
+    "balance-scale": {
+        "character": "\uf24e",
+        "searchterms": [
+            "balanced",
+            "justice",
+            "legal",
+            "measure",
+            "weight",
+            "balance-scale"
+        ]
+    },
+    "balance-scale-left": {
+        "character": "\uf515",
+        "searchterms": [
+            "justice",
+            "legal",
+            "measure",
+            "unbalanced",
+            "weight",
+            "balance-scale-left"
+        ]
+    },
+    "balance-scale-right": {
+        "character": "\uf516",
+        "searchterms": [
+            "justice",
+            "legal",
+            "measure",
+            "unbalanced",
+            "weight",
+            "balance-scale-right"
+        ]
+    },
+    "ban": {
+        "character": "\uf05e",
+        "searchterms": [
+            "abort",
+            "ban",
+            "block",
+            "cancel",
+            "delete",
+            "hide",
+            "prohibit",
+            "remove",
+            "stop",
+            "trash"
+        ]
+    },
+    "band-aid": {
+        "character": "\uf462",
+        "searchterms": [
+            "bandage",
+            "boo boo",
+            "first aid",
+            "ouch",
+            "band-aid"
+        ]
+    },
+    "bandcamp": {
+        "character": "\uf2d5",
+        "searchterms": [
+            "bandcamp"
+        ]
+    },
+    "bank": {
+        "character": "\uf19c",
+        "searchterms": [
+            "bank",
+            "building",
+            "college",
+            "higher education - students",
+            "institution",
+            "university"
+        ]
+    },
+    "bar-chart": {
+        "character": "\uf080",
+        "searchterms": [
+            "analytics",
+            "bar",
+            "chart",
+            "graph",
+            "chart-bar",
+            "bar-chart",
+            "bar-chart-o"
+        ]
+    },
+    "bar-chart-o": {
+        "character": "\uf080",
+        "searchterms": [
+            "analytics",
+            "bar",
+            "chart",
+            "graph",
+            "chart-bar",
+            "bar-chart",
+            "bar-chart-o"
+        ]
+    },
+    "barcode": {
+        "character": "\uf02a",
+        "searchterms": [
+            "info",
+            "laser",
+            "price",
+            "scan",
+            "upc",
+            "barcode"
+        ]
+    },
+    "bars": {
+        "character": "\uf0c9",
+        "searchterms": [
+            "checklist",
+            "drag",
+            "hamburger",
+            "list",
+            "menu",
+            "nav",
+            "navigation",
+            "ol",
+            "reorder",
+            "settings",
+            "todo",
+            "ul",
+            "bars",
+            "navicon"
+        ]
+    },
+    "baseball-ball": {
+        "character": "\uf433",
+        "searchterms": [
+            "foul",
+            "hardball",
+            "league",
+            "leather",
+            "mlb",
+            "softball",
+            "sport",
+            "baseball-ball"
+        ]
+    },
+    "basketball-ball": {
+        "character": "\uf434",
+        "searchterms": [
+            "dribble",
+            "dunk",
+            "hoop",
+            "nba",
+            "basketball-ball"
+        ]
+    },
+    "bath": {
+        "character": "\uf2cd",
+        "searchterms": [
+            "clean",
+            "shower",
+            "tub",
+            "wash",
+            "bath",
+            "bathtub",
+            "s15"
+        ]
+    },
+    "bathtub": {
+        "character": "\uf2cd",
+        "searchterms": [
+            "clean",
+            "shower",
+            "tub",
+            "wash",
+            "bath",
+            "bathtub",
+            "s15"
+        ]
+    },
+    "battery": {
+        "character": "\uf240",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-full",
+            "battery-4",
+            "battery"
+        ]
+    },
+    "battery-0": {
+        "character": "\uf244",
+        "searchterms": [
+            "charge",
+            "dead",
+            "power",
+            "status",
+            "battery-empty",
+            "battery-0"
+        ]
+    },
+    "battery-1": {
+        "character": "\uf243",
+        "searchterms": [
+            "charge",
+            "low",
+            "power",
+            "status",
+            "battery-quarter",
+            "battery-1"
+        ]
+    },
+    "battery-2": {
+        "character": "\uf242",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-half",
+            "battery-2"
+        ]
+    },
+    "battery-3": {
+        "character": "\uf241",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-three-quarters",
+            "battery-3"
+        ]
+    },
+    "battery-4": {
+        "character": "\uf240",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-full",
+            "battery-4",
+            "battery"
+        ]
+    },
+    "battery-empty": {
+        "character": "\uf244",
+        "searchterms": [
+            "charge",
+            "dead",
+            "power",
+            "status",
+            "battery-empty",
+            "battery-0"
+        ]
+    },
+    "battery-full": {
+        "character": "\uf240",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-full",
+            "battery-4",
+            "battery"
+        ]
+    },
+    "battery-half": {
+        "character": "\uf242",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-half",
+            "battery-2"
+        ]
+    },
+    "battery-quarter": {
+        "character": "\uf243",
+        "searchterms": [
+            "charge",
+            "low",
+            "power",
+            "status",
+            "battery-quarter",
+            "battery-1"
+        ]
+    },
+    "battery-three-quarters": {
+        "character": "\uf241",
+        "searchterms": [
+            "charge",
+            "power",
+            "status",
+            "battery-three-quarters",
+            "battery-3"
+        ]
+    },
+    "battle-net": {
+        "character": "\uf835",
+        "searchterms": [
+            "battle-net"
+        ]
+    },
+    "bed": {
+        "character": "\uf236",
+        "searchterms": [
+            "lodging",
+            "mattress",
+            "rest",
+            "sleep",
+            "travel",
+            "bed"
+        ]
+    },
+    "beer": {
+        "character": "\uf0fc",
+        "searchterms": [
+            "alcohol",
+            "ale",
+            "bar",
+            "beverage",
+            "brewery",
+            "drink",
+            "lager",
+            "liquor",
+            "mug",
+            "stein",
+            "beer"
+        ]
+    },
+    "behance": {
+        "character": "\uf1b4",
+        "searchterms": [
+            "behance"
+        ]
+    },
+    "behance-square": {
+        "character": "\uf1b5",
+        "searchterms": [
+            "behance-square"
+        ]
+    },
+    "bell": {
+        "character": "\uf0f3",
+        "searchterms": [
+            "alarm",
+            "alert",
+            "chime",
+            "notification",
+            "reminder",
+            "bell",
+            "bell-o"
+        ]
+    },
+    "bell-o": {
+        "character": "\uf0f3",
+        "searchterms": [
+            "alarm",
+            "alert",
+            "chime",
+            "notification",
+            "reminder",
+            "bell",
+            "bell-o"
+        ]
+    },
+    "bell-slash": {
+        "character": "\uf1f6",
+        "searchterms": [
+            "alert",
+            "cancel",
+            "disabled",
+            "notification",
+            "off",
+            "reminder",
+            "bell-slash",
+            "bell-slash-o"
+        ]
+    },
+    "bell-slash-o": {
+        "character": "\uf1f6",
+        "searchterms": [
+            "alert",
+            "cancel",
+            "disabled",
+            "notification",
+            "off",
+            "reminder",
+            "bell-slash",
+            "bell-slash-o"
+        ]
+    },
+    "bezier-curve": {
+        "character": "\uf55b",
+        "searchterms": [
+            "curves",
+            "illustrator",
+            "lines",
+            "path",
+            "vector",
+            "bezier-curve"
+        ]
+    },
+    "bible": {
+        "character": "\uf647",
+        "searchterms": [
+            "book",
+            "catholicism",
+            "christianity",
+            "god",
+            "holy",
+            "bible"
+        ]
+    },
+    "bicycle": {
+        "character": "\uf206",
+        "searchterms": [
+            "bike",
+            "gears",
+            "pedal",
+            "transportation",
+            "vehicle",
+            "bicycle"
+        ]
+    },
+    "biking": {
+        "character": "\uf84a",
+        "searchterms": [
+            "bicycle",
+            "bike",
+            "cycle",
+            "cycling",
+            "ride",
+            "wheel",
+            "biking"
+        ]
+    },
+    "bimobject": {
+        "character": "\uf378",
+        "searchterms": [
+            "bimobject"
+        ]
+    },
+    "binoculars": {
+        "character": "\uf1e5",
+        "searchterms": [
+            "glasses",
+            "magnify",
+            "scenic",
+            "spyglass",
+            "view",
+            "binoculars"
+        ]
+    },
+    "biohazard": {
+        "character": "\uf780",
+        "searchterms": [
+            "covid-19",
+            "danger",
+            "dangerous",
+            "hazmat",
+            "medical",
+            "radioactive",
+            "toxic",
+            "waste",
+            "zombie",
+            "biohazard"
+        ]
+    },
+    "birthday-cake": {
+        "character": "\uf1fd",
+        "searchterms": [
+            "anniversary",
+            "bakery",
+            "candles",
+            "celebration",
+            "dessert",
+            "frosting",
+            "holiday",
+            "party",
+            "pastry",
+            "birthday-cake"
+        ]
+    },
+    "bitbucket": {
+        "character": "\uf171",
+        "searchterms": [
+            "atlassian",
+            "bitbucket-square",
+            "git",
+            "bitbucket"
+        ]
+    },
+    "bitbucket-square": {
+        "character": "\uf171",
+        "searchterms": [
+            "atlassian",
+            "bitbucket-square",
+            "git",
+            "bitbucket"
+        ]
+    },
+    "bitcoin": {
+        "character": "\uf379",
+        "searchterms": [
+            "bitcoin"
+        ]
+    },
+    "bity": {
+        "character": "\uf37a",
+        "searchterms": [
+            "bity"
+        ]
+    },
+    "black-tie": {
+        "character": "\uf27e",
+        "searchterms": [
+            "black-tie"
+        ]
+    },
+    "blackberry": {
+        "character": "\uf37b",
+        "searchterms": [
+            "blackberry"
+        ]
+    },
+    "blender": {
+        "character": "\uf517",
+        "searchterms": [
+            "cocktail",
+            "milkshake",
+            "mixer",
+            "puree",
+            "smoothie",
+            "blender"
+        ]
+    },
+    "blender-phone": {
+        "character": "\uf6b6",
+        "searchterms": [
+            "appliance",
+            "cocktail",
+            "communication",
+            "fantasy",
+            "milkshake",
+            "mixer",
+            "puree",
+            "silly",
+            "smoothie",
+            "blender-phone"
+        ]
+    },
+    "blind": {
+        "character": "\uf29d",
+        "searchterms": [
+            "cane",
+            "disability",
+            "person",
+            "sight",
+            "blind"
+        ]
+    },
+    "blog": {
+        "character": "\uf781",
+        "searchterms": [
+            "journal",
+            "log",
+            "online",
+            "personal",
+            "post",
+            "web 2.0",
+            "wordpress",
+            "writing",
+            "blog"
+        ]
+    },
+    "blogger": {
+        "character": "\uf37c",
+        "searchterms": [
+            "blogger"
+        ]
+    },
+    "blogger-b": {
+        "character": "\uf37d",
+        "searchterms": [
+            "blogger-b"
+        ]
+    },
+    "bluetooth": {
+        "character": "\uf293",
+        "searchterms": [
+            "bluetooth"
+        ]
+    },
+    "bluetooth-b": {
+        "character": "\uf294",
+        "searchterms": [
+            "bluetooth-b"
+        ]
+    },
+    "bold": {
+        "character": "\uf032",
+        "searchterms": [
+            "emphasis",
+            "format",
+            "text",
+            "bold"
+        ]
+    },
+    "bolt": {
+        "character": "\uf0e7",
+        "searchterms": [
+            "electricity",
+            "lightning",
+            "weather",
+            "zap",
+            "bolt",
+            "flash"
+        ]
+    },
+    "bomb": {
+        "character": "\uf1e2",
+        "searchterms": [
+            "error",
+            "explode",
+            "fuse",
+            "grenade",
+            "warning",
+            "bomb"
+        ]
+    },
+    "bone": {
+        "character": "\uf5d7",
+        "searchterms": [
+            "calcium",
+            "dog",
+            "skeletal",
+            "skeleton",
+            "tibia",
+            "bone"
+        ]
+    },
+    "bong": {
+        "character": "\uf55c",
+        "searchterms": [
+            "aparatus",
+            "cannabis",
+            "marijuana",
+            "pipe",
+            "smoke",
+            "smoking",
+            "bong"
+        ]
+    },
+    "book": {
+        "character": "\uf02d",
+        "searchterms": [
+            "diary",
+            "documentation",
+            "journal",
+            "library",
+            "read",
+            "book"
+        ]
+    },
+    "book-dead": {
+        "character": "\uf6b7",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "crossbones",
+            "d&d",
+            "dark arts",
+            "death",
+            "dnd",
+            "documentation",
+            "evil",
+            "fantasy",
+            "halloween",
+            "holiday",
+            "necronomicon",
+            "read",
+            "skull",
+            "spell",
+            "book-dead"
+        ]
+    },
+    "book-medical": {
+        "character": "\uf7e6",
+        "searchterms": [
+            "diary",
+            "documentation",
+            "health",
+            "history",
+            "journal",
+            "library",
+            "read",
+            "record",
+            "book-medical"
+        ]
+    },
+    "book-open": {
+        "character": "\uf518",
+        "searchterms": [
+            "flyer",
+            "library",
+            "notebook",
+            "open book",
+            "pamphlet",
+            "reading",
+            "book-open"
+        ]
+    },
+    "book-reader": {
+        "character": "\uf5da",
+        "searchterms": [
+            "flyer",
+            "library",
+            "notebook",
+            "open book",
+            "pamphlet",
+            "reading",
+            "book-reader"
+        ]
+    },
+    "bookmark": {
+        "character": "\uf02e",
+        "searchterms": [
+            "favorite",
+            "marker",
+            "read",
+            "remember",
+            "save",
+            "bookmark",
+            "bookmark-o"
+        ]
+    },
+    "bookmark-o": {
+        "character": "\uf02e",
+        "searchterms": [
+            "favorite",
+            "marker",
+            "read",
+            "remember",
+            "save",
+            "bookmark",
+            "bookmark-o"
+        ]
+    },
+    "bootstrap": {
+        "character": "\uf836",
+        "searchterms": [
+            "bootstrap"
+        ]
+    },
+    "border-all": {
+        "character": "\uf84c",
+        "searchterms": [
+            "cell",
+            "grid",
+            "outline",
+            "stroke",
+            "table",
+            "border-all"
+        ]
+    },
+    "border-none": {
+        "character": "\uf850",
+        "searchterms": [
+            "cell",
+            "grid",
+            "outline",
+            "stroke",
+            "table",
+            "border-none"
+        ]
+    },
+    "border-style": {
+        "character": "\uf853",
+        "searchterms": [
+            "border-style"
+        ]
+    },
+    "bowling-ball": {
+        "character": "\uf436",
+        "searchterms": [
+            "alley",
+            "candlepin",
+            "gutter",
+            "lane",
+            "strike",
+            "tenpin",
+            "bowling-ball"
+        ]
+    },
+    "box": {
+        "character": "\uf466",
+        "searchterms": [
+            "archive",
+            "container",
+            "package",
+            "storage",
+            "box"
+        ]
+    },
+    "box-open": {
+        "character": "\uf49e",
+        "searchterms": [
+            "archive",
+            "container",
+            "package",
+            "storage",
+            "unpack",
+            "box-open"
+        ]
+    },
+    "boxes": {
+        "character": "\uf468",
+        "searchterms": [
+            "archives",
+            "inventory",
+            "storage",
+            "warehouse",
+            "boxes"
+        ]
+    },
+    "braille": {
+        "character": "\uf2a1",
+        "searchterms": [
+            "alphabet",
+            "blind",
+            "dots",
+            "raised",
+            "vision",
+            "braille"
+        ]
+    },
+    "brain": {
+        "character": "\uf5dc",
+        "searchterms": [
+            "cerebellum",
+            "gray matter",
+            "intellect",
+            "medulla oblongata",
+            "mind",
+            "noodle",
+            "wit",
+            "brain"
+        ]
+    },
+    "bread-slice": {
+        "character": "\uf7ec",
+        "searchterms": [
+            "bake",
+            "bakery",
+            "baking",
+            "dough",
+            "flour",
+            "gluten",
+            "grain",
+            "sandwich",
+            "sourdough",
+            "toast",
+            "wheat",
+            "yeast",
+            "bread-slice"
+        ]
+    },
+    "briefcase": {
+        "character": "\uf0b1",
+        "searchterms": [
+            "bag",
+            "business",
+            "luggage",
+            "office",
+            "work",
+            "briefcase"
+        ]
+    },
+    "briefcase-medical": {
+        "character": "\uf469",
+        "searchterms": [
+            "doctor",
+            "emt",
+            "first aid",
+            "health",
+            "briefcase-medical"
+        ]
+    },
+    "broadcast-tower": {
+        "character": "\uf519",
+        "searchterms": [
+            "airwaves",
+            "antenna",
+            "radio",
+            "reception",
+            "waves",
+            "broadcast-tower"
+        ]
+    },
+    "broom": {
+        "character": "\uf51a",
+        "searchterms": [
+            "clean",
+            "firebolt",
+            "fly",
+            "halloween",
+            "nimbus 2000",
+            "quidditch",
+            "sweep",
+            "witch",
+            "broom"
+        ]
+    },
+    "brush": {
+        "character": "\uf55d",
+        "searchterms": [
+            "art",
+            "bristles",
+            "color",
+            "handle",
+            "paint",
+            "brush"
+        ]
+    },
+    "btc": {
+        "character": "\uf15a",
+        "searchterms": [
+            "btc"
+        ]
+    },
+    "buffer": {
+        "character": "\uf837",
+        "searchterms": [
+            "buffer"
+        ]
+    },
+    "bug": {
+        "character": "\uf188",
+        "searchterms": [
+            "beetle",
+            "error",
+            "insect",
+            "report",
+            "bug"
+        ]
+    },
+    "building": {
+        "character": "\uf1ad",
+        "searchterms": [
+            "apartment",
+            "business",
+            "city",
+            "company",
+            "office",
+            "work",
+            "building",
+            "building-o"
+        ]
+    },
+    "building-o": {
+        "character": "\uf1ad",
+        "searchterms": [
+            "apartment",
+            "business",
+            "city",
+            "company",
+            "office",
+            "work",
+            "building",
+            "building-o"
+        ]
+    },
+    "bullhorn": {
+        "character": "\uf0a1",
+        "searchterms": [
+            "announcement",
+            "broadcast",
+            "louder",
+            "megaphone",
+            "share",
+            "bullhorn"
+        ]
+    },
+    "bullseye": {
+        "character": "\uf140",
+        "searchterms": [
+            "archery",
+            "goal",
+            "objective",
+            "target",
+            "bullseye"
+        ]
+    },
+    "burn": {
+        "character": "\uf46a",
+        "searchterms": [
+            "caliente",
+            "energy",
+            "fire",
+            "flame",
+            "gas",
+            "heat",
+            "hot",
+            "burn"
+        ]
+    },
+    "buromobelexperte": {
+        "character": "\uf37f",
+        "searchterms": [
+            "buromobelexperte"
+        ]
+    },
+    "bus": {
+        "character": "\uf207",
+        "searchterms": [
+            "public transportation",
+            "transportation",
+            "travel",
+            "vehicle",
+            "bus"
+        ]
+    },
+    "bus-alt": {
+        "character": "\uf55e",
+        "searchterms": [
+            "mta",
+            "public transportation",
+            "transportation",
+            "travel",
+            "vehicle",
+            "bus-alt"
+        ]
+    },
+    "business-time": {
+        "character": "\uf64a",
+        "searchterms": [
+            "alarm",
+            "briefcase",
+            "business socks",
+            "clock",
+            "flight of the conchords",
+            "reminder",
+            "wednesday",
+            "business-time"
+        ]
+    },
+    "buy-n-large": {
+        "character": "\uf8a6",
+        "searchterms": [
+            "buy-n-large"
+        ]
+    },
+    "buysellads": {
+        "character": "\uf20d",
+        "searchterms": [
+            "buysellads"
+        ]
+    },
+    "cab": {
+        "character": "\uf1ba",
+        "searchterms": [
+            "cab",
+            "cabbie",
+            "car",
+            "car service",
+            "lyft",
+            "machine",
+            "transportation",
+            "travel",
+            "uber",
+            "vehicle",
+            "taxi"
+        ]
+    },
+    "calculator": {
+        "character": "\uf1ec",
+        "searchterms": [
+            "abacus",
+            "addition",
+            "arithmetic",
+            "counting",
+            "math",
+            "multiplication",
+            "subtraction",
+            "calculator"
+        ]
+    },
+    "calendar": {
+        "character": "\uf133",
+        "searchterms": [
+            "calendar-o",
+            "date",
+            "event",
+            "schedule",
+            "time",
+            "when",
+            "calendar"
+        ]
+    },
+    "calendar-alt": {
+        "character": "\uf073",
+        "searchterms": [
+            "calendar",
+            "date",
+            "event",
+            "schedule",
+            "time",
+            "when",
+            "calendar-alt"
+        ]
+    },
+    "calendar-check": {
+        "character": "\uf274",
+        "searchterms": [
+            "accept",
+            "agree",
+            "appointment",
+            "confirm",
+            "correct",
+            "date",
+            "done",
+            "event",
+            "ok",
+            "schedule",
+            "select",
+            "success",
+            "tick",
+            "time",
+            "todo",
+            "when",
+            "calendar-check",
+            "calendar-check-o"
+        ]
+    },
+    "calendar-check-o": {
+        "character": "\uf274",
+        "searchterms": [
+            "accept",
+            "agree",
+            "appointment",
+            "confirm",
+            "correct",
+            "date",
+            "done",
+            "event",
+            "ok",
+            "schedule",
+            "select",
+            "success",
+            "tick",
+            "time",
+            "todo",
+            "when",
+            "calendar-check",
+            "calendar-check-o"
+        ]
+    },
+    "calendar-day": {
+        "character": "\uf783",
+        "searchterms": [
+            "date",
+            "detail",
+            "event",
+            "focus",
+            "schedule",
+            "single day",
+            "time",
+            "today",
+            "when",
+            "calendar-day"
+        ]
+    },
+    "calendar-minus": {
+        "character": "\uf272",
+        "searchterms": [
+            "calendar",
+            "date",
+            "delete",
+            "event",
+            "negative",
+            "remove",
+            "schedule",
+            "time",
+            "when",
+            "calendar-minus",
+            "calendar-minus-o"
+        ]
+    },
+    "calendar-minus-o": {
+        "character": "\uf272",
+        "searchterms": [
+            "calendar",
+            "date",
+            "delete",
+            "event",
+            "negative",
+            "remove",
+            "schedule",
+            "time",
+            "when",
+            "calendar-minus",
+            "calendar-minus-o"
+        ]
+    },
+    "calendar-o": {
+        "character": "\uf133",
+        "searchterms": [
+            "calendar-o",
+            "date",
+            "event",
+            "schedule",
+            "time",
+            "when",
+            "calendar"
+        ]
+    },
+    "calendar-plus": {
+        "character": "\uf271",
+        "searchterms": [
+            "add",
+            "calendar",
+            "create",
+            "date",
+            "event",
+            "new",
+            "positive",
+            "schedule",
+            "time",
+            "when",
+            "calendar-plus",
+            "calendar-plus-o"
+        ]
+    },
+    "calendar-plus-o": {
+        "character": "\uf271",
+        "searchterms": [
+            "add",
+            "calendar",
+            "create",
+            "date",
+            "event",
+            "new",
+            "positive",
+            "schedule",
+            "time",
+            "when",
+            "calendar-plus",
+            "calendar-plus-o"
+        ]
+    },
+    "calendar-times": {
+        "character": "\uf273",
+        "searchterms": [
+            "archive",
+            "calendar",
+            "date",
+            "delete",
+            "event",
+            "remove",
+            "schedule",
+            "time",
+            "when",
+            "x",
+            "calendar-times",
+            "calendar-times-o"
+        ]
+    },
+    "calendar-times-o": {
+        "character": "\uf273",
+        "searchterms": [
+            "archive",
+            "calendar",
+            "date",
+            "delete",
+            "event",
+            "remove",
+            "schedule",
+            "time",
+            "when",
+            "x",
+            "calendar-times",
+            "calendar-times-o"
+        ]
+    },
+    "calendar-week": {
+        "character": "\uf784",
+        "searchterms": [
+            "date",
+            "detail",
+            "event",
+            "focus",
+            "schedule",
+            "single week",
+            "time",
+            "today",
+            "when",
+            "calendar-week"
+        ]
+    },
+    "camera": {
+        "character": "\uf030",
+        "searchterms": [
+            "image",
+            "lens",
+            "photo",
+            "picture",
+            "record",
+            "shutter",
+            "video",
+            "camera"
+        ]
+    },
+    "camera-retro": {
+        "character": "\uf083",
+        "searchterms": [
+            "image",
+            "lens",
+            "photo",
+            "picture",
+            "record",
+            "shutter",
+            "video",
+            "camera-retro"
+        ]
+    },
+    "campground": {
+        "character": "\uf6bb",
+        "searchterms": [
+            "camping",
+            "fall",
+            "outdoors",
+            "teepee",
+            "tent",
+            "tipi",
+            "campground"
+        ]
+    },
+    "canadian-maple-leaf": {
+        "character": "\uf785",
+        "searchterms": [
+            "canada",
+            "flag",
+            "flora",
+            "nature",
+            "plant",
+            "canadian-maple-leaf"
+        ]
+    },
+    "candy-cane": {
+        "character": "\uf786",
+        "searchterms": [
+            "candy",
+            "christmas",
+            "holiday",
+            "mint",
+            "peppermint",
+            "striped",
+            "xmas",
+            "candy-cane"
+        ]
+    },
+    "cannabis": {
+        "character": "\uf55f",
+        "searchterms": [
+            "bud",
+            "chronic",
+            "drugs",
+            "endica",
+            "endo",
+            "ganja",
+            "marijuana",
+            "mary jane",
+            "pot",
+            "reefer",
+            "sativa",
+            "spliff",
+            "weed",
+            "whacky-tabacky",
+            "cannabis"
+        ]
+    },
+    "capsules": {
+        "character": "\uf46b",
+        "searchterms": [
+            "drugs",
+            "medicine",
+            "pills",
+            "prescription",
+            "capsules"
+        ]
+    },
+    "car": {
+        "character": "\uf1b9",
+        "searchterms": [
+            "auto",
+            "automobile",
+            "sedan",
+            "transportation",
+            "travel",
+            "vehicle",
+            "car"
+        ]
+    },
+    "car-alt": {
+        "character": "\uf5de",
+        "searchterms": [
+            "auto",
+            "automobile",
+            "sedan",
+            "transportation",
+            "travel",
+            "vehicle",
+            "car-alt"
+        ]
+    },
+    "car-battery": {
+        "character": "\uf5df",
+        "searchterms": [
+            "auto",
+            "electric",
+            "mechanic",
+            "power",
+            "car-battery"
+        ]
+    },
+    "car-crash": {
+        "character": "\uf5e1",
+        "searchterms": [
+            "accident",
+            "auto",
+            "automobile",
+            "insurance",
+            "sedan",
+            "transportation",
+            "vehicle",
+            "wreck",
+            "car-crash"
+        ]
+    },
+    "car-side": {
+        "character": "\uf5e4",
+        "searchterms": [
+            "auto",
+            "automobile",
+            "sedan",
+            "transportation",
+            "travel",
+            "vehicle",
+            "car-side"
+        ]
+    },
+    "caret-down": {
+        "character": "\uf0d7",
+        "searchterms": [
+            "arrow",
+            "dropdown",
+            "expand",
+            "menu",
+            "more",
+            "triangle",
+            "caret-down"
+        ]
+    },
+    "caret-left": {
+        "character": "\uf0d9",
+        "searchterms": [
+            "arrow",
+            "back",
+            "previous",
+            "triangle",
+            "caret-left"
+        ]
+    },
+    "caret-right": {
+        "character": "\uf0da",
+        "searchterms": [
+            "arrow",
+            "forward",
+            "next",
+            "triangle",
+            "caret-right"
+        ]
+    },
+    "caret-square-down": {
+        "character": "\uf150",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-down",
+            "dropdown",
+            "expand",
+            "menu",
+            "more",
+            "triangle",
+            "caret-square-down",
+            "toggle-down"
+        ]
+    },
+    "caret-square-left": {
+        "character": "\uf191",
+        "searchterms": [
+            "arrow",
+            "back",
+            "caret-square-o-left",
+            "previous",
+            "triangle",
+            "caret-square-left",
+            "toggle-left"
+        ]
+    },
+    "caret-square-o-down": {
+        "character": "\uf150",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-down",
+            "dropdown",
+            "expand",
+            "menu",
+            "more",
+            "triangle",
+            "caret-square-down",
+            "toggle-down"
+        ]
+    },
+    "caret-square-o-left": {
+        "character": "\uf191",
+        "searchterms": [
+            "arrow",
+            "back",
+            "caret-square-o-left",
+            "previous",
+            "triangle",
+            "caret-square-left",
+            "toggle-left"
+        ]
+    },
+    "caret-square-o-right": {
+        "character": "\uf152",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-right",
+            "forward",
+            "next",
+            "triangle",
+            "caret-square-right",
+            "toggle-right"
+        ]
+    },
+    "caret-square-o-up": {
+        "character": "\uf151",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-up",
+            "collapse",
+            "triangle",
+            "upload",
+            "caret-square-up",
+            "toggle-up"
+        ]
+    },
+    "caret-square-right": {
+        "character": "\uf152",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-right",
+            "forward",
+            "next",
+            "triangle",
+            "caret-square-right",
+            "toggle-right"
+        ]
+    },
+    "caret-square-up": {
+        "character": "\uf151",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-up",
+            "collapse",
+            "triangle",
+            "upload",
+            "caret-square-up",
+            "toggle-up"
+        ]
+    },
+    "caret-up": {
+        "character": "\uf0d8",
+        "searchterms": [
+            "arrow",
+            "collapse",
+            "triangle",
+            "caret-up"
+        ]
+    },
+    "carrot": {
+        "character": "\uf787",
+        "searchterms": [
+            "bugs bunny",
+            "orange",
+            "vegan",
+            "vegetable",
+            "carrot"
+        ]
+    },
+    "cart-arrow-down": {
+        "character": "\uf218",
+        "searchterms": [
+            "download",
+            "save",
+            "shopping",
+            "cart-arrow-down"
+        ]
+    },
+    "cart-plus": {
+        "character": "\uf217",
+        "searchterms": [
+            "add",
+            "create",
+            "new",
+            "positive",
+            "shopping",
+            "cart-plus"
+        ]
+    },
+    "cash-register": {
+        "character": "\uf788",
+        "searchterms": [
+            "buy",
+            "cha-ching",
+            "change",
+            "checkout",
+            "commerce",
+            "leaerboard",
+            "machine",
+            "pay",
+            "payment",
+            "purchase",
+            "store",
+            "cash-register"
+        ]
+    },
+    "cat": {
+        "character": "\uf6be",
+        "searchterms": [
+            "feline",
+            "halloween",
+            "holiday",
+            "kitten",
+            "kitty",
+            "meow",
+            "pet",
+            "cat"
+        ]
+    },
+    "cc": {
+        "character": "\uf20a",
+        "searchterms": [
+            "cc",
+            "deaf",
+            "hearing",
+            "subtitle",
+            "subtitling",
+            "text",
+            "video",
+            "closed-captioning"
+        ]
+    },
+    "cc-amazon-pay": {
+        "character": "\uf42d",
+        "searchterms": [
+            "cc-amazon-pay"
+        ]
+    },
+    "cc-amex": {
+        "character": "\uf1f3",
+        "searchterms": [
+            "amex",
+            "cc-amex"
+        ]
+    },
+    "cc-apple-pay": {
+        "character": "\uf416",
+        "searchterms": [
+            "cc-apple-pay"
+        ]
+    },
+    "cc-diners-club": {
+        "character": "\uf24c",
+        "searchterms": [
+            "cc-diners-club"
+        ]
+    },
+    "cc-discover": {
+        "character": "\uf1f2",
+        "searchterms": [
+            "cc-discover"
+        ]
+    },
+    "cc-jcb": {
+        "character": "\uf24b",
+        "searchterms": [
+            "cc-jcb"
+        ]
+    },
+    "cc-mastercard": {
+        "character": "\uf1f1",
+        "searchterms": [
+            "cc-mastercard"
+        ]
+    },
+    "cc-paypal": {
+        "character": "\uf1f4",
+        "searchterms": [
+            "cc-paypal"
+        ]
+    },
+    "cc-stripe": {
+        "character": "\uf1f5",
+        "searchterms": [
+            "cc-stripe"
+        ]
+    },
+    "cc-visa": {
+        "character": "\uf1f0",
+        "searchterms": [
+            "cc-visa"
+        ]
+    },
+    "centercode": {
+        "character": "\uf380",
+        "searchterms": [
+            "centercode"
+        ]
+    },
+    "centos": {
+        "character": "\uf789",
+        "searchterms": [
+            "linux",
+            "operating system",
+            "os",
+            "centos"
+        ]
+    },
+    "certificate": {
+        "character": "\uf0a3",
+        "searchterms": [
+            "badge",
+            "star",
+            "verified",
+            "certificate"
+        ]
+    },
+    "chain": {
+        "character": "\uf0c1",
+        "searchterms": [
+            "attach",
+            "attachment",
+            "chain",
+            "connect",
+            "link"
+        ]
+    },
+    "chain-broken": {
+        "character": "\uf127",
+        "searchterms": [
+            "attachment",
+            "chain",
+            "chain-broken",
+            "remove",
+            "unlink"
+        ]
+    },
+    "chair": {
+        "character": "\uf6c0",
+        "searchterms": [
+            "furniture",
+            "seat",
+            "sit",
+            "chair"
+        ]
+    },
+    "chalkboard": {
+        "character": "\uf51b",
+        "searchterms": [
+            "blackboard",
+            "learning",
+            "school",
+            "teaching",
+            "whiteboard",
+            "writing",
+            "chalkboard"
+        ]
+    },
+    "chalkboard-teacher": {
+        "character": "\uf51c",
+        "searchterms": [
+            "blackboard",
+            "instructor",
+            "learning",
+            "professor",
+            "school",
+            "whiteboard",
+            "writing",
+            "chalkboard-teacher"
+        ]
+    },
+    "charging-station": {
+        "character": "\uf5e7",
+        "searchterms": [
+            "electric",
+            "ev",
+            "tesla",
+            "vehicle",
+            "charging-station"
+        ]
+    },
+    "chart-area": {
+        "character": "\uf1fe",
+        "searchterms": [
+            "analytics",
+            "area",
+            "chart",
+            "graph",
+            "chart-area",
+            "area-chart"
+        ]
+    },
+    "chart-bar": {
+        "character": "\uf080",
+        "searchterms": [
+            "analytics",
+            "bar",
+            "chart",
+            "graph",
+            "chart-bar",
+            "bar-chart",
+            "bar-chart-o"
+        ]
+    },
+    "chart-line": {
+        "character": "\uf201",
+        "searchterms": [
+            "activity",
+            "analytics",
+            "chart",
+            "dashboard",
+            "gain",
+            "graph",
+            "increase",
+            "line",
+            "chart-line",
+            "line-chart"
+        ]
+    },
+    "chart-pie": {
+        "character": "\uf200",
+        "searchterms": [
+            "analytics",
+            "chart",
+            "diagram",
+            "graph",
+            "pie",
+            "chart-pie",
+            "pie-chart"
+        ]
+    },
+    "check": {
+        "character": "\uf00c",
+        "searchterms": [
+            "accept",
+            "agree",
+            "checkmark",
+            "confirm",
+            "correct",
+            "done",
+            "notice",
+            "notification",
+            "notify",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "yes",
+            "check"
+        ]
+    },
+    "check-circle": {
+        "character": "\uf058",
+        "searchterms": [
+            "accept",
+            "agree",
+            "confirm",
+            "correct",
+            "done",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "yes",
+            "check-circle",
+            "check-circle-o"
+        ]
+    },
+    "check-circle-o": {
+        "character": "\uf058",
+        "searchterms": [
+            "accept",
+            "agree",
+            "confirm",
+            "correct",
+            "done",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "yes",
+            "check-circle",
+            "check-circle-o"
+        ]
+    },
+    "check-double": {
+        "character": "\uf560",
+        "searchterms": [
+            "accept",
+            "agree",
+            "checkmark",
+            "confirm",
+            "correct",
+            "done",
+            "notice",
+            "notification",
+            "notify",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "check-double"
+        ]
+    },
+    "check-square": {
+        "character": "\uf14a",
+        "searchterms": [
+            "accept",
+            "agree",
+            "checkmark",
+            "confirm",
+            "correct",
+            "done",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "yes",
+            "check-square",
+            "check-square-o"
+        ]
+    },
+    "check-square-o": {
+        "character": "\uf14a",
+        "searchterms": [
+            "accept",
+            "agree",
+            "checkmark",
+            "confirm",
+            "correct",
+            "done",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "yes",
+            "check-square",
+            "check-square-o"
+        ]
+    },
+    "cheese": {
+        "character": "\uf7ef",
+        "searchterms": [
+            "cheddar",
+            "curd",
+            "gouda",
+            "melt",
+            "parmesan",
+            "sandwich",
+            "swiss",
+            "wedge",
+            "cheese"
+        ]
+    },
+    "chess": {
+        "character": "\uf439",
+        "searchterms": [
+            "board",
+            "castle",
+            "checkmate",
+            "game",
+            "king",
+            "rook",
+            "strategy",
+            "tournament",
+            "chess"
+        ]
+    },
+    "chess-bishop": {
+        "character": "\uf43a",
+        "searchterms": [
+            "board",
+            "checkmate",
+            "game",
+            "strategy",
+            "chess-bishop"
+        ]
+    },
+    "chess-board": {
+        "character": "\uf43c",
+        "searchterms": [
+            "board",
+            "checkmate",
+            "game",
+            "strategy",
+            "chess-board"
+        ]
+    },
+    "chess-king": {
+        "character": "\uf43f",
+        "searchterms": [
+            "board",
+            "checkmate",
+            "game",
+            "strategy",
+            "chess-king"
+        ]
+    },
+    "chess-knight": {
+        "character": "\uf441",
+        "searchterms": [
+            "board",
+            "checkmate",
+            "game",
+            "horse",
+            "strategy",
+            "chess-knight"
+        ]
+    },
+    "chess-pawn": {
+        "character": "\uf443",
+        "searchterms": [
+            "board",
+            "checkmate",
+            "game",
+            "strategy",
+            "chess-pawn"
+        ]
+    },
+    "chess-queen": {
+        "character": "\uf445",
+        "searchterms": [
+            "board",
+            "checkmate",
+            "game",
+            "strategy",
+            "chess-queen"
+        ]
+    },
+    "chess-rook": {
+        "character": "\uf447",
+        "searchterms": [
+            "board",
+            "castle",
+            "checkmate",
+            "game",
+            "strategy",
+            "chess-rook"
+        ]
+    },
+    "chevron-circle-down": {
+        "character": "\uf13a",
+        "searchterms": [
+            "arrow",
+            "download",
+            "dropdown",
+            "menu",
+            "more",
+            "chevron-circle-down"
+        ]
+    },
+    "chevron-circle-left": {
+        "character": "\uf137",
+        "searchterms": [
+            "arrow",
+            "back",
+            "previous",
+            "chevron-circle-left"
+        ]
+    },
+    "chevron-circle-right": {
+        "character": "\uf138",
+        "searchterms": [
+            "arrow",
+            "forward",
+            "next",
+            "chevron-circle-right"
+        ]
+    },
+    "chevron-circle-up": {
+        "character": "\uf139",
+        "searchterms": [
+            "arrow",
+            "collapse",
+            "upload",
+            "chevron-circle-up"
+        ]
+    },
+    "chevron-down": {
+        "character": "\uf078",
+        "searchterms": [
+            "arrow",
+            "download",
+            "expand",
+            "chevron-down"
+        ]
+    },
+    "chevron-left": {
+        "character": "\uf053",
+        "searchterms": [
+            "arrow",
+            "back",
+            "bracket",
+            "previous",
+            "chevron-left"
+        ]
+    },
+    "chevron-right": {
+        "character": "\uf054",
+        "searchterms": [
+            "arrow",
+            "bracket",
+            "forward",
+            "next",
+            "chevron-right"
+        ]
+    },
+    "chevron-up": {
+        "character": "\uf077",
+        "searchterms": [
+            "arrow",
+            "collapse",
+            "upload",
+            "chevron-up"
+        ]
+    },
+    "child": {
+        "character": "\uf1ae",
+        "searchterms": [
+            "boy",
+            "girl",
+            "kid",
+            "toddler",
+            "young",
+            "child"
+        ]
+    },
+    "chrome": {
+        "character": "\uf268",
+        "searchterms": [
+            "browser",
+            "chrome"
+        ]
+    },
+    "chromecast": {
+        "character": "\uf838",
+        "searchterms": [
+            "chromecast"
+        ]
+    },
+    "church": {
+        "character": "\uf51d",
+        "searchterms": [
+            "building",
+            "cathedral",
+            "chapel",
+            "community",
+            "religion",
+            "church"
+        ]
+    },
+    "circle": {
+        "character": "\uf111",
+        "searchterms": [
+            "circle-thin",
+            "diameter",
+            "dot",
+            "ellipse",
+            "notification",
+            "round",
+            "circle",
+            "circle-o"
+        ]
+    },
+    "circle-notch": {
+        "character": "\uf1ce",
+        "searchterms": [
+            "circle-o-notch",
+            "diameter",
+            "dot",
+            "ellipse",
+            "round",
+            "spinner",
+            "circle-notch"
+        ]
+    },
+    "circle-o": {
+        "character": "\uf111",
+        "searchterms": [
+            "circle-thin",
+            "diameter",
+            "dot",
+            "ellipse",
+            "notification",
+            "round",
+            "circle",
+            "circle-o"
+        ]
+    },
+    "circle-o-notch": {
+        "character": "\uf1ce",
+        "searchterms": [
+            "circle-o-notch",
+            "diameter",
+            "dot",
+            "ellipse",
+            "round",
+            "spinner",
+            "circle-notch"
+        ]
+    },
+    "circle-thin": {
+        "character": "\uf111",
+        "searchterms": [
+            "circle-thin",
+            "diameter",
+            "dot",
+            "ellipse",
+            "notification",
+            "round",
+            "circle",
+            "circle-o"
+        ]
+    },
+    "city": {
+        "character": "\uf64f",
+        "searchterms": [
+            "buildings",
+            "busy",
+            "skyscrapers",
+            "urban",
+            "windows",
+            "city"
+        ]
+    },
+    "clinic-medical": {
+        "character": "\uf7f2",
+        "searchterms": [
+            "covid-19",
+            "doctor",
+            "general practitioner",
+            "hospital",
+            "infirmary",
+            "medicine",
+            "office",
+            "outpatient",
+            "clinic-medical"
+        ]
+    },
+    "clipboard": {
+        "character": "\uf328",
+        "searchterms": [
+            "copy",
+            "notes",
+            "paste",
+            "record",
+            "clipboard"
+        ]
+    },
+    "clipboard-check": {
+        "character": "\uf46c",
+        "searchterms": [
+            "accept",
+            "agree",
+            "confirm",
+            "done",
+            "ok",
+            "select",
+            "success",
+            "tick",
+            "todo",
+            "yes",
+            "clipboard-check"
+        ]
+    },
+    "clipboard-list": {
+        "character": "\uf46d",
+        "searchterms": [
+            "checklist",
+            "completed",
+            "done",
+            "finished",
+            "intinerary",
+            "ol",
+            "schedule",
+            "tick",
+            "todo",
+            "ul",
+            "clipboard-list"
+        ]
+    },
+    "clock": {
+        "character": "\uf017",
+        "searchterms": [
+            "date",
+            "late",
+            "schedule",
+            "time",
+            "timer",
+            "timestamp",
+            "watch",
+            "clock",
+            "clock-o"
+        ]
+    },
+    "clock-o": {
+        "character": "\uf017",
+        "searchterms": [
+            "date",
+            "late",
+            "schedule",
+            "time",
+            "timer",
+            "timestamp",
+            "watch",
+            "clock",
+            "clock-o"
+        ]
+    },
+    "clone": {
+        "character": "\uf24d",
+        "searchterms": [
+            "arrange",
+            "copy",
+            "duplicate",
+            "paste",
+            "clone"
+        ]
+    },
+    "close": {
+        "character": "\uf00d",
+        "searchterms": [
+            "close",
+            "cross",
+            "error",
+            "exit",
+            "incorrect",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "wrong",
+            "x",
+            "times",
+            "remove"
+        ]
+    },
+    "closed-captioning": {
+        "character": "\uf20a",
+        "searchterms": [
+            "cc",
+            "deaf",
+            "hearing",
+            "subtitle",
+            "subtitling",
+            "text",
+            "video",
+            "closed-captioning"
+        ]
+    },
+    "cloud": {
+        "character": "\uf0c2",
+        "searchterms": [
+            "atmosphere",
+            "fog",
+            "overcast",
+            "save",
+            "upload",
+            "weather",
+            "cloud"
+        ]
+    },
+    "cloud-download": {
+        "character": "\uf381",
+        "searchterms": [
+            "download",
+            "export",
+            "save",
+            "cloud-download-alt",
+            "cloud-download"
+        ]
+    },
+    "cloud-download-alt": {
+        "character": "\uf381",
+        "searchterms": [
+            "download",
+            "export",
+            "save",
+            "cloud-download-alt",
+            "cloud-download"
+        ]
+    },
+    "cloud-meatball": {
+        "character": "\uf73b",
+        "searchterms": [
+            "FLDSMDFR",
+            "food",
+            "spaghetti",
+            "storm",
+            "cloud-meatball"
+        ]
+    },
+    "cloud-moon": {
+        "character": "\uf6c3",
+        "searchterms": [
+            "crescent",
+            "evening",
+            "lunar",
+            "night",
+            "partly cloudy",
+            "sky",
+            "cloud-moon"
+        ]
+    },
+    "cloud-moon-rain": {
+        "character": "\uf73c",
+        "searchterms": [
+            "crescent",
+            "evening",
+            "lunar",
+            "night",
+            "partly cloudy",
+            "precipitation",
+            "rain",
+            "sky",
+            "storm",
+            "cloud-moon-rain"
+        ]
+    },
+    "cloud-rain": {
+        "character": "\uf73d",
+        "searchterms": [
+            "precipitation",
+            "rain",
+            "sky",
+            "storm",
+            "cloud-rain"
+        ]
+    },
+    "cloud-showers-heavy": {
+        "character": "\uf740",
+        "searchterms": [
+            "precipitation",
+            "rain",
+            "sky",
+            "storm",
+            "cloud-showers-heavy"
+        ]
+    },
+    "cloud-sun": {
+        "character": "\uf6c4",
+        "searchterms": [
+            "clear",
+            "day",
+            "daytime",
+            "fall",
+            "outdoors",
+            "overcast",
+            "partly cloudy",
+            "cloud-sun"
+        ]
+    },
+    "cloud-sun-rain": {
+        "character": "\uf743",
+        "searchterms": [
+            "day",
+            "overcast",
+            "precipitation",
+            "storm",
+            "summer",
+            "sunshower",
+            "cloud-sun-rain"
+        ]
+    },
+    "cloud-upload": {
+        "character": "\uf382",
+        "searchterms": [
+            "cloud-upload",
+            "import",
+            "save",
+            "upload",
+            "cloud-upload-alt"
+        ]
+    },
+    "cloud-upload-alt": {
+        "character": "\uf382",
+        "searchterms": [
+            "cloud-upload",
+            "import",
+            "save",
+            "upload",
+            "cloud-upload-alt"
+        ]
+    },
+    "cloudscale": {
+        "character": "\uf383",
+        "searchterms": [
+            "cloudscale"
+        ]
+    },
+    "cloudsmith": {
+        "character": "\uf384",
+        "searchterms": [
+            "cloudsmith"
+        ]
+    },
+    "cloudversify": {
+        "character": "\uf385",
+        "searchterms": [
+            "cloudversify"
+        ]
+    },
+    "cny": {
+        "character": "\uf157",
+        "searchterms": [
+            "currency",
+            "jpy",
+            "money",
+            "yen-sign",
+            "cny",
+            "rmb",
+            "yen"
+        ]
+    },
+    "cocktail": {
+        "character": "\uf561",
+        "searchterms": [
+            "alcohol",
+            "beverage",
+            "drink",
+            "gin",
+            "glass",
+            "margarita",
+            "martini",
+            "vodka",
+            "cocktail"
+        ]
+    },
+    "code": {
+        "character": "\uf121",
+        "searchterms": [
+            "brackets",
+            "code",
+            "development",
+            "html"
+        ]
+    },
+    "code-branch": {
+        "character": "\uf126",
+        "searchterms": [
+            "branch",
+            "code-fork",
+            "fork",
+            "git",
+            "github",
+            "rebase",
+            "svn",
+            "vcs",
+            "version",
+            "code-branch"
+        ]
+    },
+    "code-fork": {
+        "character": "\uf126",
+        "searchterms": [
+            "branch",
+            "code-fork",
+            "fork",
+            "git",
+            "github",
+            "rebase",
+            "svn",
+            "vcs",
+            "version",
+            "code-branch"
+        ]
+    },
+    "codepen": {
+        "character": "\uf1cb",
+        "searchterms": [
+            "codepen"
+        ]
+    },
+    "codiepie": {
+        "character": "\uf284",
+        "searchterms": [
+            "codiepie"
+        ]
+    },
+    "coffee": {
+        "character": "\uf0f4",
+        "searchterms": [
+            "beverage",
+            "breakfast",
+            "cafe",
+            "drink",
+            "fall",
+            "morning",
+            "mug",
+            "seasonal",
+            "tea",
+            "coffee"
+        ]
+    },
+    "cog": {
+        "character": "\uf013",
+        "searchterms": [
+            "gear",
+            "mechanical",
+            "settings",
+            "sprocket",
+            "wheel",
+            "cog"
+        ]
+    },
+    "cogs": {
+        "character": "\uf085",
+        "searchterms": [
+            "gears",
+            "mechanical",
+            "settings",
+            "sprocket",
+            "wheel",
+            "cogs"
+        ]
+    },
+    "coins": {
+        "character": "\uf51e",
+        "searchterms": [
+            "currency",
+            "dime",
+            "financial",
+            "gold",
+            "money",
+            "penny",
+            "coins"
+        ]
+    },
+    "columns": {
+        "character": "\uf0db",
+        "searchterms": [
+            "browser",
+            "dashboard",
+            "organize",
+            "panes",
+            "split",
+            "columns"
+        ]
+    },
+    "comment": {
+        "character": "\uf075",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "note",
+            "notification",
+            "sms",
+            "speech",
+            "texting",
+            "comment",
+            "comment-o"
+        ]
+    },
+    "comment-alt": {
+        "character": "\uf27a",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "note",
+            "notification",
+            "sms",
+            "speech",
+            "texting",
+            "comment-alt"
+        ]
+    },
+    "comment-dollar": {
+        "character": "\uf651",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "money",
+            "note",
+            "notification",
+            "pay",
+            "sms",
+            "speech",
+            "spend",
+            "texting",
+            "transfer",
+            "comment-dollar"
+        ]
+    },
+    "comment-dots": {
+        "character": "\uf4ad",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "more",
+            "note",
+            "notification",
+            "reply",
+            "sms",
+            "speech",
+            "texting",
+            "comment-dots",
+            "commenting-o"
+        ]
+    },
+    "comment-medical": {
+        "character": "\uf7f5",
+        "searchterms": [
+            "advice",
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "diagnose",
+            "feedback",
+            "message",
+            "note",
+            "notification",
+            "prescription",
+            "sms",
+            "speech",
+            "texting",
+            "comment-medical"
+        ]
+    },
+    "comment-o": {
+        "character": "\uf075",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "note",
+            "notification",
+            "sms",
+            "speech",
+            "texting",
+            "comment",
+            "comment-o"
+        ]
+    },
+    "comment-slash": {
+        "character": "\uf4b3",
+        "searchterms": [
+            "bubble",
+            "cancel",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "mute",
+            "note",
+            "notification",
+            "quiet",
+            "sms",
+            "speech",
+            "texting",
+            "comment-slash"
+        ]
+    },
+    "commenting": {
+        "character": "\uf4ad",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "more",
+            "note",
+            "notification",
+            "reply",
+            "sms",
+            "speech",
+            "texting",
+            "comment-dots",
+            "commenting-o"
+        ]
+    },
+    "commenting-o": {
+        "character": "\uf4ad",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "more",
+            "note",
+            "notification",
+            "reply",
+            "sms",
+            "speech",
+            "texting",
+            "comment-dots",
+            "commenting-o"
+        ]
+    },
+    "comments": {
+        "character": "\uf086",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "note",
+            "notification",
+            "sms",
+            "speech",
+            "texting",
+            "comments",
+            "comments-o"
+        ]
+    },
+    "comments-dollar": {
+        "character": "\uf653",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "money",
+            "note",
+            "notification",
+            "pay",
+            "sms",
+            "speech",
+            "spend",
+            "texting",
+            "transfer",
+            "comments-dollar"
+        ]
+    },
+    "comments-o": {
+        "character": "\uf086",
+        "searchterms": [
+            "bubble",
+            "chat",
+            "commenting",
+            "conversation",
+            "feedback",
+            "message",
+            "note",
+            "notification",
+            "sms",
+            "speech",
+            "texting",
+            "comments",
+            "comments-o"
+        ]
+    },
+    "compact-disc": {
+        "character": "\uf51f",
+        "searchterms": [
+            "album",
+            "bluray",
+            "cd",
+            "disc",
+            "dvd",
+            "media",
+            "movie",
+            "music",
+            "record",
+            "video",
+            "vinyl",
+            "compact-disc"
+        ]
+    },
+    "compass": {
+        "character": "\uf14e",
+        "searchterms": [
+            "directions",
+            "directory",
+            "location",
+            "menu",
+            "navigation",
+            "safari",
+            "travel",
+            "compass"
+        ]
+    },
+    "compress": {
+        "character": "\uf066",
+        "searchterms": [
+            "collapse",
+            "fullscreen",
+            "minimize",
+            "move",
+            "resize",
+            "shrink",
+            "smaller",
+            "compress"
+        ]
+    },
+    "compress-arrows-alt": {
+        "character": "\uf78c",
+        "searchterms": [
+            "collapse",
+            "fullscreen",
+            "minimize",
+            "move",
+            "resize",
+            "shrink",
+            "smaller",
+            "compress-arrows-alt"
+        ]
+    },
+    "concierge-bell": {
+        "character": "\uf562",
+        "searchterms": [
+            "attention",
+            "hotel",
+            "receptionist",
+            "service",
+            "support",
+            "concierge-bell"
+        ]
+    },
+    "confluence": {
+        "character": "\uf78d",
+        "searchterms": [
+            "atlassian",
+            "confluence"
+        ]
+    },
+    "connectdevelop": {
+        "character": "\uf20e",
+        "searchterms": [
+            "connectdevelop"
+        ]
+    },
+    "contao": {
+        "character": "\uf26d",
+        "searchterms": [
+            "contao"
+        ]
+    },
+    "cookie": {
+        "character": "\uf563",
+        "searchterms": [
+            "baked good",
+            "chips",
+            "chocolate",
+            "eat",
+            "snack",
+            "sweet",
+            "treat",
+            "cookie"
+        ]
+    },
+    "cookie-bite": {
+        "character": "\uf564",
+        "searchterms": [
+            "baked good",
+            "bitten",
+            "chips",
+            "chocolate",
+            "eat",
+            "snack",
+            "sweet",
+            "treat",
+            "cookie-bite"
+        ]
+    },
+    "copy": {
+        "character": "\uf0c5",
+        "searchterms": [
+            "clone",
+            "duplicate",
+            "file",
+            "files-o",
+            "paper",
+            "paste",
+            "copy"
+        ]
+    },
+    "copyright": {
+        "character": "\uf1f9",
+        "searchterms": [
+            "brand",
+            "mark",
+            "register",
+            "trademark",
+            "copyright"
+        ]
+    },
+    "cotton-bureau": {
+        "character": "\uf89e",
+        "searchterms": [
+            "clothing",
+            "t-shirts",
+            "tshirts",
+            "cotton-bureau"
+        ]
+    },
+    "couch": {
+        "character": "\uf4b8",
+        "searchterms": [
+            "chair",
+            "cushion",
+            "furniture",
+            "relax",
+            "sofa",
+            "couch"
+        ]
+    },
+    "cpanel": {
+        "character": "\uf388",
+        "searchterms": [
+            "cpanel"
+        ]
+    },
+    "creative-commons": {
+        "character": "\uf25e",
+        "searchterms": [
+            "creative-commons"
+        ]
+    },
+    "creative-commons-by": {
+        "character": "\uf4e7",
+        "searchterms": [
+            "creative-commons-by"
+        ]
+    },
+    "creative-commons-nc": {
+        "character": "\uf4e8",
+        "searchterms": [
+            "creative-commons-nc"
+        ]
+    },
+    "creative-commons-nc-eu": {
+        "character": "\uf4e9",
+        "searchterms": [
+            "creative-commons-nc-eu"
+        ]
+    },
+    "creative-commons-nc-jp": {
+        "character": "\uf4ea",
+        "searchterms": [
+            "creative-commons-nc-jp"
+        ]
+    },
+    "creative-commons-nd": {
+        "character": "\uf4eb",
+        "searchterms": [
+            "creative-commons-nd"
+        ]
+    },
+    "creative-commons-pd": {
+        "character": "\uf4ec",
+        "searchterms": [
+            "creative-commons-pd"
+        ]
+    },
+    "creative-commons-pd-alt": {
+        "character": "\uf4ed",
+        "searchterms": [
+            "creative-commons-pd-alt"
+        ]
+    },
+    "creative-commons-remix": {
+        "character": "\uf4ee",
+        "searchterms": [
+            "creative-commons-remix"
+        ]
+    },
+    "creative-commons-sa": {
+        "character": "\uf4ef",
+        "searchterms": [
+            "creative-commons-sa"
+        ]
+    },
+    "creative-commons-sampling": {
+        "character": "\uf4f0",
+        "searchterms": [
+            "creative-commons-sampling"
+        ]
+    },
+    "creative-commons-sampling-plus": {
+        "character": "\uf4f1",
+        "searchterms": [
+            "creative-commons-sampling-plus"
+        ]
+    },
+    "creative-commons-share": {
+        "character": "\uf4f2",
+        "searchterms": [
+            "creative-commons-share"
+        ]
+    },
+    "creative-commons-zero": {
+        "character": "\uf4f3",
+        "searchterms": [
+            "creative-commons-zero"
+        ]
+    },
+    "credit-card": {
+        "character": "\uf09d",
+        "searchterms": [
+            "buy",
+            "checkout",
+            "credit-card-alt",
+            "debit",
+            "money",
+            "payment",
+            "purchase",
+            "credit-card"
+        ]
+    },
+    "credit-card-alt": {
+        "character": "\uf09d",
+        "searchterms": [
+            "buy",
+            "checkout",
+            "credit-card-alt",
+            "debit",
+            "money",
+            "payment",
+            "purchase",
+            "credit-card"
+        ]
+    },
+    "critical-role": {
+        "character": "\uf6c9",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "game",
+            "gaming",
+            "tabletop",
+            "critical-role"
+        ]
+    },
+    "crop": {
+        "character": "\uf125",
+        "searchterms": [
+            "design",
+            "frame",
+            "mask",
+            "resize",
+            "shrink",
+            "crop"
+        ]
+    },
+    "crop-alt": {
+        "character": "\uf565",
+        "searchterms": [
+            "design",
+            "frame",
+            "mask",
+            "resize",
+            "shrink",
+            "crop-alt"
+        ]
+    },
+    "cross": {
+        "character": "\uf654",
+        "searchterms": [
+            "catholicism",
+            "christianity",
+            "church",
+            "jesus",
+            "cross"
+        ]
+    },
+    "crosshairs": {
+        "character": "\uf05b",
+        "searchterms": [
+            "aim",
+            "bullseye",
+            "gpd",
+            "picker",
+            "position",
+            "crosshairs"
+        ]
+    },
+    "crow": {
+        "character": "\uf520",
+        "searchterms": [
+            "bird",
+            "bullfrog",
+            "fauna",
+            "halloween",
+            "holiday",
+            "toad",
+            "crow"
+        ]
+    },
+    "crown": {
+        "character": "\uf521",
+        "searchterms": [
+            "award",
+            "favorite",
+            "king",
+            "queen",
+            "royal",
+            "tiara",
+            "crown"
+        ]
+    },
+    "crutch": {
+        "character": "\uf7f7",
+        "searchterms": [
+            "cane",
+            "injury",
+            "mobility",
+            "wheelchair",
+            "crutch"
+        ]
+    },
+    "css3": {
+        "character": "\uf13c",
+        "searchterms": [
+            "code",
+            "css3"
+        ]
+    },
+    "css3-alt": {
+        "character": "\uf38b",
+        "searchterms": [
+            "css3-alt"
+        ]
+    },
+    "cube": {
+        "character": "\uf1b2",
+        "searchterms": [
+            "3d",
+            "block",
+            "dice",
+            "package",
+            "square",
+            "tesseract",
+            "cube"
+        ]
+    },
+    "cubes": {
+        "character": "\uf1b3",
+        "searchterms": [
+            "3d",
+            "block",
+            "dice",
+            "package",
+            "pyramid",
+            "square",
+            "stack",
+            "tesseract",
+            "cubes"
+        ]
+    },
+    "cut": {
+        "character": "\uf0c4",
+        "searchterms": [
+            "clip",
+            "scissors",
+            "snip",
+            "cut"
+        ]
+    },
+    "cutlery": {
+        "character": "\uf2e7",
+        "searchterms": [
+            "cutlery",
+            "dining",
+            "dinner",
+            "eat",
+            "food",
+            "fork",
+            "knife",
+            "restaurant",
+            "utensils"
+        ]
+    },
+    "cuttlefish": {
+        "character": "\uf38c",
+        "searchterms": [
+            "cuttlefish"
+        ]
+    },
+    "d-and-d": {
+        "character": "\uf38d",
+        "searchterms": [
+            "d-and-d"
+        ]
+    },
+    "d-and-d-beyond": {
+        "character": "\uf6ca",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "gaming",
+            "tabletop",
+            "d-and-d-beyond"
+        ]
+    },
+    "dashboard": {
+        "character": "\uf3fd",
+        "searchterms": [
+            "dashboard",
+            "fast",
+            "odometer",
+            "speed",
+            "speedometer",
+            "tachometer-alt",
+            "tachometer"
+        ]
+    },
+    "dashcube": {
+        "character": "\uf210",
+        "searchterms": [
+            "dashcube"
+        ]
+    },
+    "database": {
+        "character": "\uf1c0",
+        "searchterms": [
+            "computer",
+            "development",
+            "directory",
+            "memory",
+            "storage",
+            "database"
+        ]
+    },
+    "deaf": {
+        "character": "\uf2a4",
+        "searchterms": [
+            "ear",
+            "hearing",
+            "sign language",
+            "deaf",
+            "deafness",
+            "hard-of-hearing"
+        ]
+    },
+    "deafness": {
+        "character": "\uf2a4",
+        "searchterms": [
+            "ear",
+            "hearing",
+            "sign language",
+            "deaf",
+            "deafness",
+            "hard-of-hearing"
+        ]
+    },
+    "dedent": {
+        "character": "\uf03b",
+        "searchterms": [
+            "align",
+            "justify",
+            "paragraph",
+            "tab",
+            "outdent",
+            "dedent"
+        ]
+    },
+    "delicious": {
+        "character": "\uf1a5",
+        "searchterms": [
+            "delicious"
+        ]
+    },
+    "democrat": {
+        "character": "\uf747",
+        "searchterms": [
+            "american",
+            "democratic party",
+            "donkey",
+            "election",
+            "left",
+            "left-wing",
+            "liberal",
+            "politics",
+            "usa",
+            "democrat"
+        ]
+    },
+    "deploydog": {
+        "character": "\uf38e",
+        "searchterms": [
+            "deploydog"
+        ]
+    },
+    "deskpro": {
+        "character": "\uf38f",
+        "searchterms": [
+            "deskpro"
+        ]
+    },
+    "desktop": {
+        "character": "\uf108",
+        "searchterms": [
+            "computer",
+            "cpu",
+            "demo",
+            "desktop",
+            "device",
+            "imac",
+            "machine",
+            "monitor",
+            "pc",
+            "screen"
+        ]
+    },
+    "dev": {
+        "character": "\uf6cc",
+        "searchterms": [
+            "dev"
+        ]
+    },
+    "deviantart": {
+        "character": "\uf1bd",
+        "searchterms": [
+            "deviantart"
+        ]
+    },
+    "dharmachakra": {
+        "character": "\uf655",
+        "searchterms": [
+            "buddhism",
+            "buddhist",
+            "wheel of dharma",
+            "dharmachakra"
+        ]
+    },
+    "dhl": {
+        "character": "\uf790",
+        "searchterms": [
+            "Dalsey",
+            "Hillblom and Lynn",
+            "german",
+            "package",
+            "shipping",
+            "dhl"
+        ]
+    },
+    "diagnoses": {
+        "character": "\uf470",
+        "searchterms": [
+            "analyze",
+            "detect",
+            "diagnosis",
+            "examine",
+            "medicine",
+            "diagnoses"
+        ]
+    },
+    "diamond": {
+        "character": "\uf3a5",
+        "searchterms": [
+            "diamond",
+            "jewelry",
+            "sapphire",
+            "stone",
+            "treasure",
+            "gem"
+        ]
+    },
+    "diaspora": {
+        "character": "\uf791",
+        "searchterms": [
+            "diaspora"
+        ]
+    },
+    "dice": {
+        "character": "\uf522",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice"
+        ]
+    },
+    "dice-d20": {
+        "character": "\uf6cf",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "chance",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "gambling",
+            "game",
+            "roll",
+            "dice-d20"
+        ]
+    },
+    "dice-d6": {
+        "character": "\uf6d1",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "chance",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "gambling",
+            "game",
+            "roll",
+            "dice-d6"
+        ]
+    },
+    "dice-five": {
+        "character": "\uf523",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice-five"
+        ]
+    },
+    "dice-four": {
+        "character": "\uf524",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice-four"
+        ]
+    },
+    "dice-one": {
+        "character": "\uf525",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice-one"
+        ]
+    },
+    "dice-six": {
+        "character": "\uf526",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice-six"
+        ]
+    },
+    "dice-three": {
+        "character": "\uf527",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice-three"
+        ]
+    },
+    "dice-two": {
+        "character": "\uf528",
+        "searchterms": [
+            "chance",
+            "gambling",
+            "game",
+            "roll",
+            "dice-two"
+        ]
+    },
+    "digg": {
+        "character": "\uf1a6",
+        "searchterms": [
+            "digg"
+        ]
+    },
+    "digital-ocean": {
+        "character": "\uf391",
+        "searchterms": [
+            "digital-ocean"
+        ]
+    },
+    "digital-tachograph": {
+        "character": "\uf566",
+        "searchterms": [
+            "data",
+            "distance",
+            "speed",
+            "tachometer",
+            "digital-tachograph"
+        ]
+    },
+    "directions": {
+        "character": "\uf5eb",
+        "searchterms": [
+            "map",
+            "navigation",
+            "sign",
+            "turn",
+            "directions"
+        ]
+    },
+    "discord": {
+        "character": "\uf392",
+        "searchterms": [
+            "discord"
+        ]
+    },
+    "discourse": {
+        "character": "\uf393",
+        "searchterms": [
+            "discourse"
+        ]
+    },
+    "divide": {
+        "character": "\uf529",
+        "searchterms": [
+            "arithmetic",
+            "calculus",
+            "division",
+            "math",
+            "divide"
+        ]
+    },
+    "dizzy": {
+        "character": "\uf567",
+        "searchterms": [
+            "dazed",
+            "dead",
+            "disapprove",
+            "emoticon",
+            "face",
+            "dizzy"
+        ]
+    },
+    "dna": {
+        "character": "\uf471",
+        "searchterms": [
+            "double helix",
+            "genetic",
+            "helix",
+            "molecule",
+            "protein",
+            "dna"
+        ]
+    },
+    "dochub": {
+        "character": "\uf394",
+        "searchterms": [
+            "dochub"
+        ]
+    },
+    "docker": {
+        "character": "\uf395",
+        "searchterms": [
+            "docker"
+        ]
+    },
+    "dog": {
+        "character": "\uf6d3",
+        "searchterms": [
+            "animal",
+            "canine",
+            "fauna",
+            "mammal",
+            "pet",
+            "pooch",
+            "puppy",
+            "woof",
+            "dog"
+        ]
+    },
+    "dollar": {
+        "character": "\uf155",
+        "searchterms": [
+            "$",
+            "cost",
+            "dollar-sign",
+            "money",
+            "price",
+            "usd",
+            "dollar"
+        ]
+    },
+    "dollar-sign": {
+        "character": "\uf155",
+        "searchterms": [
+            "$",
+            "cost",
+            "dollar-sign",
+            "money",
+            "price",
+            "usd",
+            "dollar"
+        ]
+    },
+    "dolly": {
+        "character": "\uf472",
+        "searchterms": [
+            "carry",
+            "shipping",
+            "transport",
+            "dolly"
+        ]
+    },
+    "dolly-flatbed": {
+        "character": "\uf474",
+        "searchterms": [
+            "carry",
+            "inventory",
+            "shipping",
+            "transport",
+            "dolly-flatbed"
+        ]
+    },
+    "donate": {
+        "character": "\uf4b9",
+        "searchterms": [
+            "contribute",
+            "generosity",
+            "gift",
+            "give",
+            "donate"
+        ]
+    },
+    "door-closed": {
+        "character": "\uf52a",
+        "searchterms": [
+            "enter",
+            "exit",
+            "locked",
+            "door-closed"
+        ]
+    },
+    "door-open": {
+        "character": "\uf52b",
+        "searchterms": [
+            "enter",
+            "exit",
+            "welcome",
+            "door-open"
+        ]
+    },
+    "dot-circle": {
+        "character": "\uf192",
+        "searchterms": [
+            "bullseye",
+            "notification",
+            "target",
+            "dot-circle",
+            "dot-circle-o"
+        ]
+    },
+    "dot-circle-o": {
+        "character": "\uf192",
+        "searchterms": [
+            "bullseye",
+            "notification",
+            "target",
+            "dot-circle",
+            "dot-circle-o"
+        ]
+    },
+    "dove": {
+        "character": "\uf4ba",
+        "searchterms": [
+            "bird",
+            "fauna",
+            "flying",
+            "peace",
+            "war",
+            "dove"
+        ]
+    },
+    "download": {
+        "character": "\uf019",
+        "searchterms": [
+            "export",
+            "hard drive",
+            "save",
+            "transfer",
+            "download"
+        ]
+    },
+    "draft2digital": {
+        "character": "\uf396",
+        "searchterms": [
+            "draft2digital"
+        ]
+    },
+    "drafting-compass": {
+        "character": "\uf568",
+        "searchterms": [
+            "design",
+            "map",
+            "mechanical drawing",
+            "plot",
+            "plotting",
+            "drafting-compass"
+        ]
+    },
+    "dragon": {
+        "character": "\uf6d5",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "fire",
+            "lizard",
+            "serpent",
+            "dragon"
+        ]
+    },
+    "draw-polygon": {
+        "character": "\uf5ee",
+        "searchterms": [
+            "anchors",
+            "lines",
+            "object",
+            "render",
+            "shape",
+            "draw-polygon"
+        ]
+    },
+    "dribbble": {
+        "character": "\uf17d",
+        "searchterms": [
+            "dribbble"
+        ]
+    },
+    "dribbble-square": {
+        "character": "\uf397",
+        "searchterms": [
+            "dribbble-square"
+        ]
+    },
+    "drivers-license": {
+        "character": "\uf2c2",
+        "searchterms": [
+            "contact",
+            "demographics",
+            "document",
+            "identification",
+            "issued",
+            "profile",
+            "id-card",
+            "drivers-license",
+            "id-card-o",
+            "drivers-license-o"
+        ]
+    },
+    "drivers-license-o": {
+        "character": "\uf2c2",
+        "searchterms": [
+            "contact",
+            "demographics",
+            "document",
+            "identification",
+            "issued",
+            "profile",
+            "id-card",
+            "drivers-license",
+            "id-card-o",
+            "drivers-license-o"
+        ]
+    },
+    "dropbox": {
+        "character": "\uf16b",
+        "searchterms": [
+            "dropbox"
+        ]
+    },
+    "drum": {
+        "character": "\uf569",
+        "searchterms": [
+            "instrument",
+            "music",
+            "percussion",
+            "snare",
+            "sound",
+            "drum"
+        ]
+    },
+    "drum-steelpan": {
+        "character": "\uf56a",
+        "searchterms": [
+            "calypso",
+            "instrument",
+            "music",
+            "percussion",
+            "reggae",
+            "snare",
+            "sound",
+            "steel",
+            "tropical",
+            "drum-steelpan"
+        ]
+    },
+    "drumstick-bite": {
+        "character": "\uf6d7",
+        "searchterms": [
+            "bone",
+            "chicken",
+            "leg",
+            "meat",
+            "poultry",
+            "turkey",
+            "drumstick-bite"
+        ]
+    },
+    "drupal": {
+        "character": "\uf1a9",
+        "searchterms": [
+            "drupal"
+        ]
+    },
+    "dumbbell": {
+        "character": "\uf44b",
+        "searchterms": [
+            "exercise",
+            "gym",
+            "strength",
+            "weight",
+            "weight-lifting",
+            "dumbbell"
+        ]
+    },
+    "dumpster": {
+        "character": "\uf793",
+        "searchterms": [
+            "alley",
+            "bin",
+            "commercial",
+            "trash",
+            "waste",
+            "dumpster"
+        ]
+    },
+    "dumpster-fire": {
+        "character": "\uf794",
+        "searchterms": [
+            "alley",
+            "bin",
+            "commercial",
+            "danger",
+            "dangerous",
+            "euphemism",
+            "flame",
+            "heat",
+            "hot",
+            "trash",
+            "waste",
+            "dumpster-fire"
+        ]
+    },
+    "dungeon": {
+        "character": "\uf6d9",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "building",
+            "d&d",
+            "dnd",
+            "door",
+            "entrance",
+            "fantasy",
+            "gate",
+            "dungeon"
+        ]
+    },
+    "dyalog": {
+        "character": "\uf399",
+        "searchterms": [
+            "dyalog"
+        ]
+    },
+    "earlybirds": {
+        "character": "\uf39a",
+        "searchterms": [
+            "earlybirds"
+        ]
+    },
+    "ebay": {
+        "character": "\uf4f4",
+        "searchterms": [
+            "ebay"
+        ]
+    },
+    "edge": {
+        "character": "\uf282",
+        "searchterms": [
+            "browser",
+            "ie",
+            "edge"
+        ]
+    },
+    "edit": {
+        "character": "\uf044",
+        "searchterms": [
+            "edit",
+            "pen",
+            "pencil",
+            "update",
+            "write",
+            "pencil-square-o"
+        ]
+    },
+    "eercast": {
+        "character": "\uf2da",
+        "searchterms": [
+            "eercast",
+            "sellcast"
+        ]
+    },
+    "egg": {
+        "character": "\uf7fb",
+        "searchterms": [
+            "breakfast",
+            "chicken",
+            "easter",
+            "shell",
+            "yolk",
+            "egg"
+        ]
+    },
+    "eject": {
+        "character": "\uf052",
+        "searchterms": [
+            "abort",
+            "cancel",
+            "cd",
+            "discharge",
+            "eject"
+        ]
+    },
+    "elementor": {
+        "character": "\uf430",
+        "searchterms": [
+            "elementor"
+        ]
+    },
+    "ellipsis-h": {
+        "character": "\uf141",
+        "searchterms": [
+            "dots",
+            "drag",
+            "kebab",
+            "list",
+            "menu",
+            "nav",
+            "navigation",
+            "ol",
+            "reorder",
+            "settings",
+            "ul",
+            "ellipsis-h"
+        ]
+    },
+    "ellipsis-v": {
+        "character": "\uf142",
+        "searchterms": [
+            "dots",
+            "drag",
+            "kebab",
+            "list",
+            "menu",
+            "nav",
+            "navigation",
+            "ol",
+            "reorder",
+            "settings",
+            "ul",
+            "ellipsis-v"
+        ]
+    },
+    "ello": {
+        "character": "\uf5f1",
+        "searchterms": [
+            "ello"
+        ]
+    },
+    "ember": {
+        "character": "\uf423",
+        "searchterms": [
+            "ember"
+        ]
+    },
+    "empire": {
+        "character": "\uf1d1",
+        "searchterms": [
+            "empire",
+            "ge"
+        ]
+    },
+    "envelope": {
+        "character": "\uf0e0",
+        "searchterms": [
+            "e-mail",
+            "email",
+            "letter",
+            "mail",
+            "message",
+            "notification",
+            "support",
+            "envelope",
+            "envelope-o"
+        ]
+    },
+    "envelope-o": {
+        "character": "\uf0e0",
+        "searchterms": [
+            "e-mail",
+            "email",
+            "letter",
+            "mail",
+            "message",
+            "notification",
+            "support",
+            "envelope",
+            "envelope-o"
+        ]
+    },
+    "envelope-open": {
+        "character": "\uf2b6",
+        "searchterms": [
+            "e-mail",
+            "email",
+            "letter",
+            "mail",
+            "message",
+            "notification",
+            "support",
+            "envelope-open",
+            "envelope-open-o"
+        ]
+    },
+    "envelope-open-o": {
+        "character": "\uf2b6",
+        "searchterms": [
+            "e-mail",
+            "email",
+            "letter",
+            "mail",
+            "message",
+            "notification",
+            "support",
+            "envelope-open",
+            "envelope-open-o"
+        ]
+    },
+    "envelope-open-text": {
+        "character": "\uf658",
+        "searchterms": [
+            "e-mail",
+            "email",
+            "letter",
+            "mail",
+            "message",
+            "notification",
+            "support",
+            "envelope-open-text"
+        ]
+    },
+    "envelope-square": {
+        "character": "\uf199",
+        "searchterms": [
+            "e-mail",
+            "email",
+            "letter",
+            "mail",
+            "message",
+            "notification",
+            "support",
+            "envelope-square"
+        ]
+    },
+    "envira": {
+        "character": "\uf299",
+        "searchterms": [
+            "leaf",
+            "envira"
+        ]
+    },
+    "equals": {
+        "character": "\uf52c",
+        "searchterms": [
+            "arithmetic",
+            "even",
+            "match",
+            "math",
+            "equals"
+        ]
+    },
+    "eraser": {
+        "character": "\uf12d",
+        "searchterms": [
+            "art",
+            "delete",
+            "remove",
+            "rubber",
+            "eraser"
+        ]
+    },
+    "erlang": {
+        "character": "\uf39d",
+        "searchterms": [
+            "erlang"
+        ]
+    },
+    "ethereum": {
+        "character": "\uf42e",
+        "searchterms": [
+            "ethereum"
+        ]
+    },
+    "ethernet": {
+        "character": "\uf796",
+        "searchterms": [
+            "cable",
+            "cat 5",
+            "cat 6",
+            "connection",
+            "hardware",
+            "internet",
+            "network",
+            "wired",
+            "ethernet"
+        ]
+    },
+    "etsy": {
+        "character": "\uf2d7",
+        "searchterms": [
+            "etsy"
+        ]
+    },
+    "eur": {
+        "character": "\uf153",
+        "searchterms": [
+            "currency",
+            "dollar",
+            "exchange",
+            "money",
+            "euro-sign",
+            "eur",
+            "euro"
+        ]
+    },
+    "euro": {
+        "character": "\uf153",
+        "searchterms": [
+            "currency",
+            "dollar",
+            "exchange",
+            "money",
+            "euro-sign",
+            "eur",
+            "euro"
+        ]
+    },
+    "euro-sign": {
+        "character": "\uf153",
+        "searchterms": [
+            "currency",
+            "dollar",
+            "exchange",
+            "money",
+            "euro-sign",
+            "eur",
+            "euro"
+        ]
+    },
+    "evernote": {
+        "character": "\uf839",
+        "searchterms": [
+            "evernote"
+        ]
+    },
+    "exchange": {
+        "character": "\uf362",
+        "searchterms": [
+            "arrow",
+            "arrows",
+            "exchange",
+            "reciprocate",
+            "return",
+            "swap",
+            "transfer",
+            "exchange-alt"
+        ]
+    },
+    "exchange-alt": {
+        "character": "\uf362",
+        "searchterms": [
+            "arrow",
+            "arrows",
+            "exchange",
+            "reciprocate",
+            "return",
+            "swap",
+            "transfer",
+            "exchange-alt"
+        ]
+    },
+    "exclamation": {
+        "character": "\uf12a",
+        "searchterms": [
+            "alert",
+            "danger",
+            "error",
+            "important",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "warning",
+            "exclamation"
+        ]
+    },
+    "exclamation-circle": {
+        "character": "\uf06a",
+        "searchterms": [
+            "alert",
+            "danger",
+            "error",
+            "important",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "warning",
+            "exclamation-circle"
+        ]
+    },
+    "exclamation-triangle": {
+        "character": "\uf071",
+        "searchterms": [
+            "alert",
+            "danger",
+            "error",
+            "important",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "warning",
+            "exclamation-triangle"
+        ]
+    },
+    "expand": {
+        "character": "\uf065",
+        "searchterms": [
+            "bigger",
+            "enlarge",
+            "fullscreen",
+            "resize",
+            "expand"
+        ]
+    },
+    "expand-arrows-alt": {
+        "character": "\uf31e",
+        "searchterms": [
+            "bigger",
+            "enlarge",
+            "fullscreen",
+            "move",
+            "resize",
+            "expand-arrows-alt"
+        ]
+    },
+    "expeditedssl": {
+        "character": "\uf23e",
+        "searchterms": [
+            "expeditedssl"
+        ]
+    },
+    "external-link": {
+        "character": "\uf35d",
+        "searchterms": [
+            "external-link",
+            "new",
+            "open",
+            "share",
+            "external-link-alt"
+        ]
+    },
+    "external-link-alt": {
+        "character": "\uf35d",
+        "searchterms": [
+            "external-link",
+            "new",
+            "open",
+            "share",
+            "external-link-alt"
+        ]
+    },
+    "external-link-square": {
+        "character": "\uf360",
+        "searchterms": [
+            "external-link-square",
+            "new",
+            "open",
+            "share",
+            "external-link-square-alt"
+        ]
+    },
+    "external-link-square-alt": {
+        "character": "\uf360",
+        "searchterms": [
+            "external-link-square",
+            "new",
+            "open",
+            "share",
+            "external-link-square-alt"
+        ]
+    },
+    "eye": {
+        "character": "\uf06e",
+        "searchterms": [
+            "look",
+            "optic",
+            "see",
+            "seen",
+            "show",
+            "sight",
+            "views",
+            "visible",
+            "eye"
+        ]
+    },
+    "eye-dropper": {
+        "character": "\uf1fb",
+        "searchterms": [
+            "beaker",
+            "clone",
+            "color",
+            "copy",
+            "eyedropper",
+            "pipette",
+            "eye-dropper"
+        ]
+    },
+    "eye-slash": {
+        "character": "\uf070",
+        "searchterms": [
+            "blind",
+            "hide",
+            "show",
+            "toggle",
+            "unseen",
+            "views",
+            "visible",
+            "visiblity",
+            "eye-slash"
+        ]
+    },
+    "eyedropper": {
+        "character": "\uf1fb",
+        "searchterms": [
+            "beaker",
+            "clone",
+            "color",
+            "copy",
+            "eyedropper",
+            "pipette",
+            "eye-dropper"
+        ]
+    },
+    "fa": {
+        "character": "\uf2b4",
+        "searchterms": [
+            "meanpath",
+            "font-awesome",
+            "fa"
+        ]
+    },
+    "facebook": {
+        "character": "\uf09a",
+        "searchterms": [
+            "facebook-official",
+            "social network",
+            "facebook"
+        ]
+    },
+    "facebook-f": {
+        "character": "\uf39e",
+        "searchterms": [
+            "facebook",
+            "facebook-f"
+        ]
+    },
+    "facebook-messenger": {
+        "character": "\uf39f",
+        "searchterms": [
+            "facebook-messenger"
+        ]
+    },
+    "facebook-official": {
+        "character": "\uf09a",
+        "searchterms": [
+            "facebook-official",
+            "social network",
+            "facebook"
+        ]
+    },
+    "facebook-square": {
+        "character": "\uf082",
+        "searchterms": [
+            "social network",
+            "facebook-square"
+        ]
+    },
+    "fan": {
+        "character": "\uf863",
+        "searchterms": [
+            "ac",
+            "air conditioning",
+            "blade",
+            "blower",
+            "cool",
+            "hot",
+            "fan"
+        ]
+    },
+    "fantasy-flight-games": {
+        "character": "\uf6dc",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "game",
+            "gaming",
+            "tabletop",
+            "fantasy-flight-games"
+        ]
+    },
+    "fast-backward": {
+        "character": "\uf049",
+        "searchterms": [
+            "beginning",
+            "first",
+            "previous",
+            "rewind",
+            "start",
+            "fast-backward"
+        ]
+    },
+    "fast-forward": {
+        "character": "\uf050",
+        "searchterms": [
+            "end",
+            "last",
+            "next",
+            "fast-forward"
+        ]
+    },
+    "fax": {
+        "character": "\uf1ac",
+        "searchterms": [
+            "business",
+            "communicate",
+            "copy",
+            "facsimile",
+            "send",
+            "fax"
+        ]
+    },
+    "feather": {
+        "character": "\uf52d",
+        "searchterms": [
+            "bird",
+            "light",
+            "plucked",
+            "quill",
+            "write",
+            "feather"
+        ]
+    },
+    "feather-alt": {
+        "character": "\uf56b",
+        "searchterms": [
+            "bird",
+            "light",
+            "plucked",
+            "quill",
+            "write",
+            "feather-alt"
+        ]
+    },
+    "fedex": {
+        "character": "\uf797",
+        "searchterms": [
+            "Federal Express",
+            "package",
+            "shipping",
+            "fedex"
+        ]
+    },
+    "fedora": {
+        "character": "\uf798",
+        "searchterms": [
+            "linux",
+            "operating system",
+            "os",
+            "fedora"
+        ]
+    },
+    "feed": {
+        "character": "\uf09e",
+        "searchterms": [
+            "blog",
+            "feed",
+            "journal",
+            "news",
+            "writing",
+            "rss"
+        ]
+    },
+    "female": {
+        "character": "\uf182",
+        "searchterms": [
+            "human",
+            "person",
+            "profile",
+            "user",
+            "woman",
+            "female"
+        ]
+    },
+    "fighter-jet": {
+        "character": "\uf0fb",
+        "searchterms": [
+            "airplane",
+            "fast",
+            "fly",
+            "goose",
+            "maverick",
+            "plane",
+            "quick",
+            "top gun",
+            "transportation",
+            "travel",
+            "fighter-jet"
+        ]
+    },
+    "figma": {
+        "character": "\uf799",
+        "searchterms": [
+            "app",
+            "design",
+            "interface",
+            "figma"
+        ]
+    },
+    "file": {
+        "character": "\uf15b",
+        "searchterms": [
+            "document",
+            "new",
+            "page",
+            "pdf",
+            "resume",
+            "file",
+            "file-o"
+        ]
+    },
+    "file-alt": {
+        "character": "\uf15c",
+        "searchterms": [
+            "document",
+            "file-text",
+            "invoice",
+            "new",
+            "page",
+            "pdf",
+            "file-alt",
+            "file-text-o"
+        ]
+    },
+    "file-archive": {
+        "character": "\uf1c6",
+        "searchterms": [
+            ".zip",
+            "bundle",
+            "compress",
+            "compression",
+            "download",
+            "zip",
+            "file-archive",
+            "file-archive-o",
+            "file-zip-o"
+        ]
+    },
+    "file-archive-o": {
+        "character": "\uf1c6",
+        "searchterms": [
+            ".zip",
+            "bundle",
+            "compress",
+            "compression",
+            "download",
+            "zip",
+            "file-archive",
+            "file-archive-o",
+            "file-zip-o"
+        ]
+    },
+    "file-audio": {
+        "character": "\uf1c7",
+        "searchterms": [
+            "document",
+            "mp3",
+            "music",
+            "page",
+            "play",
+            "sound",
+            "file-audio",
+            "file-audio-o",
+            "file-sound-o"
+        ]
+    },
+    "file-audio-o": {
+        "character": "\uf1c7",
+        "searchterms": [
+            "document",
+            "mp3",
+            "music",
+            "page",
+            "play",
+            "sound",
+            "file-audio",
+            "file-audio-o",
+            "file-sound-o"
+        ]
+    },
+    "file-code": {
+        "character": "\uf1c9",
+        "searchterms": [
+            "css",
+            "development",
+            "document",
+            "html",
+            "file-code",
+            "file-code-o"
+        ]
+    },
+    "file-code-o": {
+        "character": "\uf1c9",
+        "searchterms": [
+            "css",
+            "development",
+            "document",
+            "html",
+            "file-code",
+            "file-code-o"
+        ]
+    },
+    "file-contract": {
+        "character": "\uf56c",
+        "searchterms": [
+            "agreement",
+            "binding",
+            "document",
+            "legal",
+            "signature",
+            "file-contract"
+        ]
+    },
+    "file-csv": {
+        "character": "\uf6dd",
+        "searchterms": [
+            "document",
+            "excel",
+            "numbers",
+            "spreadsheets",
+            "table",
+            "file-csv"
+        ]
+    },
+    "file-download": {
+        "character": "\uf56d",
+        "searchterms": [
+            "document",
+            "export",
+            "save",
+            "file-download"
+        ]
+    },
+    "file-excel": {
+        "character": "\uf1c3",
+        "searchterms": [
+            "csv",
+            "document",
+            "numbers",
+            "spreadsheets",
+            "table",
+            "file-excel",
+            "file-excel-o"
+        ]
+    },
+    "file-excel-o": {
+        "character": "\uf1c3",
+        "searchterms": [
+            "csv",
+            "document",
+            "numbers",
+            "spreadsheets",
+            "table",
+            "file-excel",
+            "file-excel-o"
+        ]
+    },
+    "file-export": {
+        "character": "\uf56e",
+        "searchterms": [
+            "download",
+            "save",
+            "file-export"
+        ]
+    },
+    "file-image": {
+        "character": "\uf1c5",
+        "searchterms": [
+            "document",
+            "image",
+            "jpg",
+            "photo",
+            "png",
+            "file-image",
+            "file-image-o",
+            "file-photo-o",
+            "file-picture-o"
+        ]
+    },
+    "file-image-o": {
+        "character": "\uf1c5",
+        "searchterms": [
+            "document",
+            "image",
+            "jpg",
+            "photo",
+            "png",
+            "file-image",
+            "file-image-o",
+            "file-photo-o",
+            "file-picture-o"
+        ]
+    },
+    "file-import": {
+        "character": "\uf56f",
+        "searchterms": [
+            "copy",
+            "document",
+            "send",
+            "upload",
+            "file-import"
+        ]
+    },
+    "file-invoice": {
+        "character": "\uf570",
+        "searchterms": [
+            "account",
+            "bill",
+            "charge",
+            "document",
+            "payment",
+            "receipt",
+            "file-invoice"
+        ]
+    },
+    "file-invoice-dollar": {
+        "character": "\uf571",
+        "searchterms": [
+            "$",
+            "account",
+            "bill",
+            "charge",
+            "document",
+            "dollar-sign",
+            "money",
+            "payment",
+            "receipt",
+            "usd",
+            "file-invoice-dollar"
+        ]
+    },
+    "file-medical": {
+        "character": "\uf477",
+        "searchterms": [
+            "document",
+            "health",
+            "history",
+            "prescription",
+            "record",
+            "file-medical"
+        ]
+    },
+    "file-medical-alt": {
+        "character": "\uf478",
+        "searchterms": [
+            "document",
+            "health",
+            "history",
+            "prescription",
+            "record",
+            "file-medical-alt"
+        ]
+    },
+    "file-movie-o": {
+        "character": "\uf1c8",
+        "searchterms": [
+            "document",
+            "m4v",
+            "movie",
+            "mp4",
+            "play",
+            "file-video",
+            "file-video-o",
+            "file-movie-o"
+        ]
+    },
+    "file-o": {
+        "character": "\uf15b",
+        "searchterms": [
+            "document",
+            "new",
+            "page",
+            "pdf",
+            "resume",
+            "file",
+            "file-o"
+        ]
+    },
+    "file-pdf": {
+        "character": "\uf1c1",
+        "searchterms": [
+            "acrobat",
+            "document",
+            "preview",
+            "save",
+            "file-pdf",
+            "file-pdf-o"
+        ]
+    },
+    "file-pdf-o": {
+        "character": "\uf1c1",
+        "searchterms": [
+            "acrobat",
+            "document",
+            "preview",
+            "save",
+            "file-pdf",
+            "file-pdf-o"
+        ]
+    },
+    "file-photo-o": {
+        "character": "\uf1c5",
+        "searchterms": [
+            "document",
+            "image",
+            "jpg",
+            "photo",
+            "png",
+            "file-image",
+            "file-image-o",
+            "file-photo-o",
+            "file-picture-o"
+        ]
+    },
+    "file-picture-o": {
+        "character": "\uf1c5",
+        "searchterms": [
+            "document",
+            "image",
+            "jpg",
+            "photo",
+            "png",
+            "file-image",
+            "file-image-o",
+            "file-photo-o",
+            "file-picture-o"
+        ]
+    },
+    "file-powerpoint": {
+        "character": "\uf1c4",
+        "searchterms": [
+            "display",
+            "document",
+            "keynote",
+            "presentation",
+            "file-powerpoint",
+            "file-powerpoint-o"
+        ]
+    },
+    "file-powerpoint-o": {
+        "character": "\uf1c4",
+        "searchterms": [
+            "display",
+            "document",
+            "keynote",
+            "presentation",
+            "file-powerpoint",
+            "file-powerpoint-o"
+        ]
+    },
+    "file-prescription": {
+        "character": "\uf572",
+        "searchterms": [
+            "document",
+            "drugs",
+            "medical",
+            "medicine",
+            "rx",
+            "file-prescription"
+        ]
+    },
+    "file-signature": {
+        "character": "\uf573",
+        "searchterms": [
+            "John Hancock",
+            "contract",
+            "document",
+            "name",
+            "file-signature"
+        ]
+    },
+    "file-sound-o": {
+        "character": "\uf1c7",
+        "searchterms": [
+            "document",
+            "mp3",
+            "music",
+            "page",
+            "play",
+            "sound",
+            "file-audio",
+            "file-audio-o",
+            "file-sound-o"
+        ]
+    },
+    "file-text": {
+        "character": "\uf15c",
+        "searchterms": [
+            "document",
+            "file-text",
+            "invoice",
+            "new",
+            "page",
+            "pdf",
+            "file-alt",
+            "file-text-o"
+        ]
+    },
+    "file-text-o": {
+        "character": "\uf15c",
+        "searchterms": [
+            "document",
+            "file-text",
+            "invoice",
+            "new",
+            "page",
+            "pdf",
+            "file-alt",
+            "file-text-o"
+        ]
+    },
+    "file-upload": {
+        "character": "\uf574",
+        "searchterms": [
+            "document",
+            "import",
+            "page",
+            "save",
+            "file-upload"
+        ]
+    },
+    "file-video": {
+        "character": "\uf1c8",
+        "searchterms": [
+            "document",
+            "m4v",
+            "movie",
+            "mp4",
+            "play",
+            "file-video",
+            "file-video-o",
+            "file-movie-o"
+        ]
+    },
+    "file-video-o": {
+        "character": "\uf1c8",
+        "searchterms": [
+            "document",
+            "m4v",
+            "movie",
+            "mp4",
+            "play",
+            "file-video",
+            "file-video-o",
+            "file-movie-o"
+        ]
+    },
+    "file-word": {
+        "character": "\uf1c2",
+        "searchterms": [
+            "document",
+            "edit",
+            "page",
+            "text",
+            "writing",
+            "file-word",
+            "file-word-o"
+        ]
+    },
+    "file-word-o": {
+        "character": "\uf1c2",
+        "searchterms": [
+            "document",
+            "edit",
+            "page",
+            "text",
+            "writing",
+            "file-word",
+            "file-word-o"
+        ]
+    },
+    "file-zip-o": {
+        "character": "\uf1c6",
+        "searchterms": [
+            ".zip",
+            "bundle",
+            "compress",
+            "compression",
+            "download",
+            "zip",
+            "file-archive",
+            "file-archive-o",
+            "file-zip-o"
+        ]
+    },
+    "files-o": {
+        "character": "\uf0c5",
+        "searchterms": [
+            "clone",
+            "duplicate",
+            "file",
+            "files-o",
+            "paper",
+            "paste",
+            "copy"
+        ]
+    },
+    "fill": {
+        "character": "\uf575",
+        "searchterms": [
+            "bucket",
+            "color",
+            "paint",
+            "paint bucket",
+            "fill"
+        ]
+    },
+    "fill-drip": {
+        "character": "\uf576",
+        "searchterms": [
+            "bucket",
+            "color",
+            "drop",
+            "paint",
+            "paint bucket",
+            "spill",
+            "fill-drip"
+        ]
+    },
+    "film": {
+        "character": "\uf008",
+        "searchterms": [
+            "cinema",
+            "movie",
+            "strip",
+            "video",
+            "film"
+        ]
+    },
+    "filter": {
+        "character": "\uf0b0",
+        "searchterms": [
+            "funnel",
+            "options",
+            "separate",
+            "sort",
+            "filter"
+        ]
+    },
+    "fingerprint": {
+        "character": "\uf577",
+        "searchterms": [
+            "human",
+            "id",
+            "identification",
+            "lock",
+            "smudge",
+            "touch",
+            "unique",
+            "unlock",
+            "fingerprint"
+        ]
+    },
+    "fire": {
+        "character": "\uf06d",
+        "searchterms": [
+            "burn",
+            "caliente",
+            "flame",
+            "heat",
+            "hot",
+            "popular",
+            "fire"
+        ]
+    },
+    "fire-alt": {
+        "character": "\uf7e4",
+        "searchterms": [
+            "burn",
+            "caliente",
+            "flame",
+            "heat",
+            "hot",
+            "popular",
+            "fire-alt"
+        ]
+    },
+    "fire-extinguisher": {
+        "character": "\uf134",
+        "searchterms": [
+            "burn",
+            "caliente",
+            "fire fighter",
+            "flame",
+            "heat",
+            "hot",
+            "rescue",
+            "fire-extinguisher"
+        ]
+    },
+    "firefox": {
+        "character": "\uf269",
+        "searchterms": [
+            "browser",
+            "firefox"
+        ]
+    },
+    "first-aid": {
+        "character": "\uf479",
+        "searchterms": [
+            "emergency",
+            "emt",
+            "health",
+            "medical",
+            "rescue",
+            "first-aid"
+        ]
+    },
+    "first-order": {
+        "character": "\uf2b0",
+        "searchterms": [
+            "first-order"
+        ]
+    },
+    "first-order-alt": {
+        "character": "\uf50a",
+        "searchterms": [
+            "first-order-alt"
+        ]
+    },
+    "firstdraft": {
+        "character": "\uf3a1",
+        "searchterms": [
+            "firstdraft"
+        ]
+    },
+    "fish": {
+        "character": "\uf578",
+        "searchterms": [
+            "fauna",
+            "gold",
+            "seafood",
+            "swimming",
+            "fish"
+        ]
+    },
+    "fist-raised": {
+        "character": "\uf6de",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "hand",
+            "ki",
+            "monk",
+            "resist",
+            "strength",
+            "unarmed combat",
+            "fist-raised"
+        ]
+    },
+    "flag": {
+        "character": "\uf024",
+        "searchterms": [
+            "country",
+            "notice",
+            "notification",
+            "notify",
+            "pole",
+            "report",
+            "symbol",
+            "flag",
+            "flag-o"
+        ]
+    },
+    "flag-checkered": {
+        "character": "\uf11e",
+        "searchterms": [
+            "notice",
+            "notification",
+            "notify",
+            "pole",
+            "racing",
+            "report",
+            "symbol",
+            "flag-checkered"
+        ]
+    },
+    "flag-o": {
+        "character": "\uf024",
+        "searchterms": [
+            "country",
+            "notice",
+            "notification",
+            "notify",
+            "pole",
+            "report",
+            "symbol",
+            "flag",
+            "flag-o"
+        ]
+    },
+    "flag-usa": {
+        "character": "\uf74d",
+        "searchterms": [
+            "betsy ross",
+            "country",
+            "old glory",
+            "stars",
+            "stripes",
+            "symbol",
+            "flag-usa"
+        ]
+    },
+    "flash": {
+        "character": "\uf0e7",
+        "searchterms": [
+            "electricity",
+            "lightning",
+            "weather",
+            "zap",
+            "bolt",
+            "flash"
+        ]
+    },
+    "flask": {
+        "character": "\uf0c3",
+        "searchterms": [
+            "beaker",
+            "experimental",
+            "labs",
+            "science",
+            "flask"
+        ]
+    },
+    "flickr": {
+        "character": "\uf16e",
+        "searchterms": [
+            "flickr"
+        ]
+    },
+    "flipboard": {
+        "character": "\uf44d",
+        "searchterms": [
+            "flipboard"
+        ]
+    },
+    "floppy-o": {
+        "character": "\uf0c7",
+        "searchterms": [
+            "disk",
+            "download",
+            "floppy",
+            "floppy-o",
+            "save"
+        ]
+    },
+    "flushed": {
+        "character": "\uf579",
+        "searchterms": [
+            "embarrassed",
+            "emoticon",
+            "face",
+            "flushed"
+        ]
+    },
+    "fly": {
+        "character": "\uf417",
+        "searchterms": [
+            "fly"
+        ]
+    },
+    "folder": {
+        "character": "\uf07b",
+        "searchterms": [
+            "archive",
+            "directory",
+            "document",
+            "file",
+            "folder",
+            "folder-o"
+        ]
+    },
+    "folder-minus": {
+        "character": "\uf65d",
+        "searchterms": [
+            "archive",
+            "delete",
+            "directory",
+            "document",
+            "file",
+            "negative",
+            "remove",
+            "folder-minus"
+        ]
+    },
+    "folder-o": {
+        "character": "\uf07b",
+        "searchterms": [
+            "archive",
+            "directory",
+            "document",
+            "file",
+            "folder",
+            "folder-o"
+        ]
+    },
+    "folder-open": {
+        "character": "\uf07c",
+        "searchterms": [
+            "archive",
+            "directory",
+            "document",
+            "empty",
+            "file",
+            "new",
+            "folder-open",
+            "folder-open-o"
+        ]
+    },
+    "folder-open-o": {
+        "character": "\uf07c",
+        "searchterms": [
+            "archive",
+            "directory",
+            "document",
+            "empty",
+            "file",
+            "new",
+            "folder-open",
+            "folder-open-o"
+        ]
+    },
+    "folder-plus": {
+        "character": "\uf65e",
+        "searchterms": [
+            "add",
+            "archive",
+            "create",
+            "directory",
+            "document",
+            "file",
+            "new",
+            "positive",
+            "folder-plus"
+        ]
+    },
+    "font": {
+        "character": "\uf031",
+        "searchterms": [
+            "alphabet",
+            "glyph",
+            "text",
+            "type",
+            "typeface",
+            "font"
+        ]
+    },
+    "font-awesome": {
+        "character": "\uf2b4",
+        "searchterms": [
+            "meanpath",
+            "font-awesome",
+            "fa"
+        ]
+    },
+    "font-awesome-alt": {
+        "character": "\uf35c",
+        "searchterms": [
+            "font-awesome-alt"
+        ]
+    },
+    "font-awesome-flag": {
+        "character": "\uf425",
+        "searchterms": [
+            "font-awesome-flag"
+        ]
+    },
+    "font-awesome-logo-full": {
+        "character": "\uf4e6",
+        "searchterms": [
+            "font-awesome-logo-full"
+        ]
+    },
+    "fonticons": {
+        "character": "\uf280",
+        "searchterms": [
+            "fonticons"
+        ]
+    },
+    "fonticons-fi": {
+        "character": "\uf3a2",
+        "searchterms": [
+            "fonticons-fi"
+        ]
+    },
+    "football-ball": {
+        "character": "\uf44e",
+        "searchterms": [
+            "ball",
+            "fall",
+            "nfl",
+            "pigskin",
+            "seasonal",
+            "football-ball"
+        ]
+    },
+    "fort-awesome": {
+        "character": "\uf286",
+        "searchterms": [
+            "castle",
+            "fort-awesome"
+        ]
+    },
+    "fort-awesome-alt": {
+        "character": "\uf3a3",
+        "searchterms": [
+            "castle",
+            "fort-awesome-alt"
+        ]
+    },
+    "forumbee": {
+        "character": "\uf211",
+        "searchterms": [
+            "forumbee"
+        ]
+    },
+    "forward": {
+        "character": "\uf04e",
+        "searchterms": [
+            "forward",
+            "next",
+            "skip"
+        ]
+    },
+    "foursquare": {
+        "character": "\uf180",
+        "searchterms": [
+            "foursquare"
+        ]
+    },
+    "free-code-camp": {
+        "character": "\uf2c5",
+        "searchterms": [
+            "free-code-camp"
+        ]
+    },
+    "freebsd": {
+        "character": "\uf3a4",
+        "searchterms": [
+            "freebsd"
+        ]
+    },
+    "frog": {
+        "character": "\uf52e",
+        "searchterms": [
+            "amphibian",
+            "bullfrog",
+            "fauna",
+            "hop",
+            "kermit",
+            "kiss",
+            "prince",
+            "ribbit",
+            "toad",
+            "wart",
+            "frog"
+        ]
+    },
+    "frown": {
+        "character": "\uf119",
+        "searchterms": [
+            "disapprove",
+            "emoticon",
+            "face",
+            "rating",
+            "sad",
+            "frown",
+            "frown-o"
+        ]
+    },
+    "frown-o": {
+        "character": "\uf119",
+        "searchterms": [
+            "disapprove",
+            "emoticon",
+            "face",
+            "rating",
+            "sad",
+            "frown",
+            "frown-o"
+        ]
+    },
+    "frown-open": {
+        "character": "\uf57a",
+        "searchterms": [
+            "disapprove",
+            "emoticon",
+            "face",
+            "rating",
+            "sad",
+            "frown-open"
+        ]
+    },
+    "fulcrum": {
+        "character": "\uf50b",
+        "searchterms": [
+            "fulcrum"
+        ]
+    },
+    "funnel-dollar": {
+        "character": "\uf662",
+        "searchterms": [
+            "filter",
+            "money",
+            "options",
+            "separate",
+            "sort",
+            "funnel-dollar"
+        ]
+    },
+    "futbol": {
+        "character": "\uf1e3",
+        "searchterms": [
+            "ball",
+            "football",
+            "mls",
+            "soccer",
+            "futbol",
+            "futbol-o",
+            "soccer-ball-o"
+        ]
+    },
+    "futbol-o": {
+        "character": "\uf1e3",
+        "searchterms": [
+            "ball",
+            "football",
+            "mls",
+            "soccer",
+            "futbol",
+            "futbol-o",
+            "soccer-ball-o"
+        ]
+    },
+    "galactic-republic": {
+        "character": "\uf50c",
+        "searchterms": [
+            "politics",
+            "star wars",
+            "galactic-republic"
+        ]
+    },
+    "galactic-senate": {
+        "character": "\uf50d",
+        "searchterms": [
+            "star wars",
+            "galactic-senate"
+        ]
+    },
+    "gamepad": {
+        "character": "\uf11b",
+        "searchterms": [
+            "arcade",
+            "controller",
+            "d-pad",
+            "joystick",
+            "video",
+            "video game",
+            "gamepad"
+        ]
+    },
+    "gas-pump": {
+        "character": "\uf52f",
+        "searchterms": [
+            "car",
+            "fuel",
+            "gasoline",
+            "petrol",
+            "gas-pump"
+        ]
+    },
+    "gavel": {
+        "character": "\uf0e3",
+        "searchterms": [
+            "hammer",
+            "judge",
+            "law",
+            "lawyer",
+            "opinion",
+            "gavel",
+            "legal"
+        ]
+    },
+    "gbp": {
+        "character": "\uf154",
+        "searchterms": [
+            "currency",
+            "gbp",
+            "money",
+            "pound-sign"
+        ]
+    },
+    "ge": {
+        "character": "\uf1d1",
+        "searchterms": [
+            "empire",
+            "ge"
+        ]
+    },
+    "gear": {
+        "character": "\uf013",
+        "searchterms": [
+            "gear",
+            "mechanical",
+            "settings",
+            "sprocket",
+            "wheel",
+            "cog"
+        ]
+    },
+    "gears": {
+        "character": "\uf085",
+        "searchterms": [
+            "gears",
+            "mechanical",
+            "settings",
+            "sprocket",
+            "wheel",
+            "cogs"
+        ]
+    },
+    "gem": {
+        "character": "\uf3a5",
+        "searchterms": [
+            "diamond",
+            "jewelry",
+            "sapphire",
+            "stone",
+            "treasure",
+            "gem"
+        ]
+    },
+    "genderless": {
+        "character": "\uf22d",
+        "searchterms": [
+            "androgynous",
+            "asexual",
+            "sexless",
+            "genderless"
+        ]
+    },
+    "get-pocket": {
+        "character": "\uf265",
+        "searchterms": [
+            "get-pocket"
+        ]
+    },
+    "gg": {
+        "character": "\uf260",
+        "searchterms": [
+            "gg"
+        ]
+    },
+    "gg-circle": {
+        "character": "\uf261",
+        "searchterms": [
+            "gg-circle"
+        ]
+    },
+    "ghost": {
+        "character": "\uf6e2",
+        "searchterms": [
+            "apparition",
+            "blinky",
+            "clyde",
+            "floating",
+            "halloween",
+            "holiday",
+            "inky",
+            "pinky",
+            "spirit",
+            "ghost"
+        ]
+    },
+    "gift": {
+        "character": "\uf06b",
+        "searchterms": [
+            "christmas",
+            "generosity",
+            "giving",
+            "holiday",
+            "party",
+            "present",
+            "wrapped",
+            "xmas",
+            "gift"
+        ]
+    },
+    "gifts": {
+        "character": "\uf79c",
+        "searchterms": [
+            "christmas",
+            "generosity",
+            "giving",
+            "holiday",
+            "party",
+            "present",
+            "wrapped",
+            "xmas",
+            "gifts"
+        ]
+    },
+    "git": {
+        "character": "\uf1d3",
+        "searchterms": [
+            "git"
+        ]
+    },
+    "git-alt": {
+        "character": "\uf841",
+        "searchterms": [
+            "git-alt"
+        ]
+    },
+    "git-square": {
+        "character": "\uf1d2",
+        "searchterms": [
+            "git-square"
+        ]
+    },
+    "github": {
+        "character": "\uf09b",
+        "searchterms": [
+            "octocat",
+            "github"
+        ]
+    },
+    "github-alt": {
+        "character": "\uf113",
+        "searchterms": [
+            "octocat",
+            "github-alt"
+        ]
+    },
+    "github-square": {
+        "character": "\uf092",
+        "searchterms": [
+            "octocat",
+            "github-square"
+        ]
+    },
+    "gitkraken": {
+        "character": "\uf3a6",
+        "searchterms": [
+            "gitkraken"
+        ]
+    },
+    "gitlab": {
+        "character": "\uf296",
+        "searchterms": [
+            "Axosoft",
+            "gitlab"
+        ]
+    },
+    "gitter": {
+        "character": "\uf426",
+        "searchterms": [
+            "gitter"
+        ]
+    },
+    "gittip": {
+        "character": "\uf184",
+        "searchterms": [
+            "favorite",
+            "heart",
+            "like",
+            "love",
+            "gratipay",
+            "gittip"
+        ]
+    },
+    "glass": {
+        "character": "\uf000",
+        "searchterms": [
+            "alcohol",
+            "bar",
+            "beverage",
+            "drink",
+            "liquor",
+            "glass-martini",
+            "glass"
+        ]
+    },
+    "glass-cheers": {
+        "character": "\uf79f",
+        "searchterms": [
+            "alcohol",
+            "bar",
+            "beverage",
+            "celebration",
+            "champagne",
+            "clink",
+            "drink",
+            "holiday",
+            "new year's eve",
+            "party",
+            "toast",
+            "glass-cheers"
+        ]
+    },
+    "glass-martini": {
+        "character": "\uf000",
+        "searchterms": [
+            "alcohol",
+            "bar",
+            "beverage",
+            "drink",
+            "liquor",
+            "glass-martini",
+            "glass"
+        ]
+    },
+    "glass-martini-alt": {
+        "character": "\uf57b",
+        "searchterms": [
+            "alcohol",
+            "bar",
+            "beverage",
+            "drink",
+            "liquor",
+            "glass-martini-alt"
+        ]
+    },
+    "glass-whiskey": {
+        "character": "\uf7a0",
+        "searchterms": [
+            "alcohol",
+            "bar",
+            "beverage",
+            "bourbon",
+            "drink",
+            "liquor",
+            "neat",
+            "rye",
+            "scotch",
+            "whisky",
+            "glass-whiskey"
+        ]
+    },
+    "glasses": {
+        "character": "\uf530",
+        "searchterms": [
+            "hipster",
+            "nerd",
+            "reading",
+            "sight",
+            "spectacles",
+            "vision",
+            "glasses"
+        ]
+    },
+    "glide": {
+        "character": "\uf2a5",
+        "searchterms": [
+            "glide"
+        ]
+    },
+    "glide-g": {
+        "character": "\uf2a6",
+        "searchterms": [
+            "glide-g"
+        ]
+    },
+    "globe": {
+        "character": "\uf0ac",
+        "searchterms": [
+            "all",
+            "coordinates",
+            "country",
+            "earth",
+            "global",
+            "gps",
+            "language",
+            "localize",
+            "location",
+            "map",
+            "online",
+            "place",
+            "planet",
+            "translate",
+            "travel",
+            "world",
+            "globe"
+        ]
+    },
+    "globe-africa": {
+        "character": "\uf57c",
+        "searchterms": [
+            "all",
+            "country",
+            "earth",
+            "global",
+            "gps",
+            "language",
+            "localize",
+            "location",
+            "map",
+            "online",
+            "place",
+            "planet",
+            "translate",
+            "travel",
+            "world",
+            "globe-africa"
+        ]
+    },
+    "globe-americas": {
+        "character": "\uf57d",
+        "searchterms": [
+            "all",
+            "country",
+            "earth",
+            "global",
+            "gps",
+            "language",
+            "localize",
+            "location",
+            "map",
+            "online",
+            "place",
+            "planet",
+            "translate",
+            "travel",
+            "world",
+            "globe-americas"
+        ]
+    },
+    "globe-asia": {
+        "character": "\uf57e",
+        "searchterms": [
+            "all",
+            "country",
+            "earth",
+            "global",
+            "gps",
+            "language",
+            "localize",
+            "location",
+            "map",
+            "online",
+            "place",
+            "planet",
+            "translate",
+            "travel",
+            "world",
+            "globe-asia"
+        ]
+    },
+    "globe-europe": {
+        "character": "\uf7a2",
+        "searchterms": [
+            "all",
+            "country",
+            "earth",
+            "global",
+            "gps",
+            "language",
+            "localize",
+            "location",
+            "map",
+            "online",
+            "place",
+            "planet",
+            "translate",
+            "travel",
+            "world",
+            "globe-europe"
+        ]
+    },
+    "gofore": {
+        "character": "\uf3a7",
+        "searchterms": [
+            "gofore"
+        ]
+    },
+    "golf-ball": {
+        "character": "\uf450",
+        "searchterms": [
+            "caddy",
+            "eagle",
+            "putt",
+            "tee",
+            "golf-ball"
+        ]
+    },
+    "goodreads": {
+        "character": "\uf3a8",
+        "searchterms": [
+            "goodreads"
+        ]
+    },
+    "goodreads-g": {
+        "character": "\uf3a9",
+        "searchterms": [
+            "goodreads-g"
+        ]
+    },
+    "google": {
+        "character": "\uf1a0",
+        "searchterms": [
+            "google"
+        ]
+    },
+    "google-drive": {
+        "character": "\uf3aa",
+        "searchterms": [
+            "google-drive"
+        ]
+    },
+    "google-play": {
+        "character": "\uf3ab",
+        "searchterms": [
+            "google-play"
+        ]
+    },
+    "google-plus": {
+        "character": "\uf2b3",
+        "searchterms": [
+            "google-plus-circle",
+            "google-plus-official",
+            "google-plus"
+        ]
+    },
+    "google-plus-circle": {
+        "character": "\uf2b3",
+        "searchterms": [
+            "google-plus-circle",
+            "google-plus-official",
+            "google-plus"
+        ]
+    },
+    "google-plus-g": {
+        "character": "\uf0d5",
+        "searchterms": [
+            "google-plus",
+            "social network",
+            "google-plus-g"
+        ]
+    },
+    "google-plus-official": {
+        "character": "\uf2b3",
+        "searchterms": [
+            "google-plus-circle",
+            "google-plus-official",
+            "google-plus"
+        ]
+    },
+    "google-plus-square": {
+        "character": "\uf0d4",
+        "searchterms": [
+            "social network",
+            "google-plus-square"
+        ]
+    },
+    "google-wallet": {
+        "character": "\uf1ee",
+        "searchterms": [
+            "google-wallet"
+        ]
+    },
+    "gopuram": {
+        "character": "\uf664",
+        "searchterms": [
+            "building",
+            "entrance",
+            "hinduism",
+            "temple",
+            "tower",
+            "gopuram"
+        ]
+    },
+    "graduation-cap": {
+        "character": "\uf19d",
+        "searchterms": [
+            "ceremony",
+            "college",
+            "graduate",
+            "learning",
+            "school",
+            "student",
+            "graduation-cap",
+            "mortar-board"
+        ]
+    },
+    "gratipay": {
+        "character": "\uf184",
+        "searchterms": [
+            "favorite",
+            "heart",
+            "like",
+            "love",
+            "gratipay",
+            "gittip"
+        ]
+    },
+    "grav": {
+        "character": "\uf2d6",
+        "searchterms": [
+            "grav"
+        ]
+    },
+    "greater-than": {
+        "character": "\uf531",
+        "searchterms": [
+            "arithmetic",
+            "compare",
+            "math",
+            "greater-than"
+        ]
+    },
+    "greater-than-equal": {
+        "character": "\uf532",
+        "searchterms": [
+            "arithmetic",
+            "compare",
+            "math",
+            "greater-than-equal"
+        ]
+    },
+    "grimace": {
+        "character": "\uf57f",
+        "searchterms": [
+            "cringe",
+            "emoticon",
+            "face",
+            "teeth",
+            "grimace"
+        ]
+    },
+    "grin": {
+        "character": "\uf580",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "laugh",
+            "smile",
+            "grin"
+        ]
+    },
+    "grin-alt": {
+        "character": "\uf581",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "laugh",
+            "smile",
+            "grin-alt"
+        ]
+    },
+    "grin-beam": {
+        "character": "\uf582",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "laugh",
+            "smile",
+            "grin-beam"
+        ]
+    },
+    "grin-beam-sweat": {
+        "character": "\uf583",
+        "searchterms": [
+            "embarass",
+            "emoticon",
+            "face",
+            "smile",
+            "grin-beam-sweat"
+        ]
+    },
+    "grin-hearts": {
+        "character": "\uf584",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "love",
+            "smile",
+            "grin-hearts"
+        ]
+    },
+    "grin-squint": {
+        "character": "\uf585",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "laugh",
+            "smile",
+            "grin-squint"
+        ]
+    },
+    "grin-squint-tears": {
+        "character": "\uf586",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "happy",
+            "smile",
+            "grin-squint-tears"
+        ]
+    },
+    "grin-stars": {
+        "character": "\uf587",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "star-struck",
+            "grin-stars"
+        ]
+    },
+    "grin-tears": {
+        "character": "\uf588",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "grin-tears"
+        ]
+    },
+    "grin-tongue": {
+        "character": "\uf589",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "grin-tongue"
+        ]
+    },
+    "grin-tongue-squint": {
+        "character": "\uf58a",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "grin-tongue-squint"
+        ]
+    },
+    "grin-tongue-wink": {
+        "character": "\uf58b",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "grin-tongue-wink"
+        ]
+    },
+    "grin-wink": {
+        "character": "\uf58c",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "flirt",
+            "laugh",
+            "smile",
+            "grin-wink"
+        ]
+    },
+    "grip-horizontal": {
+        "character": "\uf58d",
+        "searchterms": [
+            "affordance",
+            "drag",
+            "drop",
+            "grab",
+            "handle",
+            "grip-horizontal"
+        ]
+    },
+    "grip-lines": {
+        "character": "\uf7a4",
+        "searchterms": [
+            "affordance",
+            "drag",
+            "drop",
+            "grab",
+            "handle",
+            "grip-lines"
+        ]
+    },
+    "grip-lines-vertical": {
+        "character": "\uf7a5",
+        "searchterms": [
+            "affordance",
+            "drag",
+            "drop",
+            "grab",
+            "handle",
+            "grip-lines-vertical"
+        ]
+    },
+    "grip-vertical": {
+        "character": "\uf58e",
+        "searchterms": [
+            "affordance",
+            "drag",
+            "drop",
+            "grab",
+            "handle",
+            "grip-vertical"
+        ]
+    },
+    "gripfire": {
+        "character": "\uf3ac",
+        "searchterms": [
+            "gripfire"
+        ]
+    },
+    "group": {
+        "character": "\uf0c0",
+        "searchterms": [
+            "friends",
+            "group",
+            "people",
+            "persons",
+            "profiles",
+            "team",
+            "users"
+        ]
+    },
+    "grunt": {
+        "character": "\uf3ad",
+        "searchterms": [
+            "grunt"
+        ]
+    },
+    "guitar": {
+        "character": "\uf7a6",
+        "searchterms": [
+            "acoustic",
+            "instrument",
+            "music",
+            "rock",
+            "rock and roll",
+            "song",
+            "strings",
+            "guitar"
+        ]
+    },
+    "gulp": {
+        "character": "\uf3ae",
+        "searchterms": [
+            "gulp"
+        ]
+    },
+    "h-square": {
+        "character": "\uf0fd",
+        "searchterms": [
+            "directions",
+            "emergency",
+            "hospital",
+            "hotel",
+            "map",
+            "h-square"
+        ]
+    },
+    "hacker-news": {
+        "character": "\uf1d4",
+        "searchterms": [
+            "hacker-news",
+            "y-combinator-square",
+            "yc-square"
+        ]
+    },
+    "hacker-news-square": {
+        "character": "\uf3af",
+        "searchterms": [
+            "hacker-news-square"
+        ]
+    },
+    "hackerrank": {
+        "character": "\uf5f7",
+        "searchterms": [
+            "hackerrank"
+        ]
+    },
+    "hamburger": {
+        "character": "\uf805",
+        "searchterms": [
+            "bacon",
+            "beef",
+            "burger",
+            "burger king",
+            "cheeseburger",
+            "fast food",
+            "grill",
+            "ground beef",
+            "mcdonalds",
+            "sandwich",
+            "hamburger"
+        ]
+    },
+    "hammer": {
+        "character": "\uf6e3",
+        "searchterms": [
+            "admin",
+            "fix",
+            "repair",
+            "settings",
+            "tool",
+            "hammer"
+        ]
+    },
+    "hamsa": {
+        "character": "\uf665",
+        "searchterms": [
+            "amulet",
+            "christianity",
+            "islam",
+            "jewish",
+            "judaism",
+            "muslim",
+            "protection",
+            "hamsa"
+        ]
+    },
+    "hand-grab-o": {
+        "character": "\uf255",
+        "searchterms": [
+            "fist",
+            "game",
+            "roshambo",
+            "hand-rock",
+            "hand-rock-o",
+            "hand-grab-o"
+        ]
+    },
+    "hand-holding": {
+        "character": "\uf4bd",
+        "searchterms": [
+            "carry",
+            "lift",
+            "hand-holding"
+        ]
+    },
+    "hand-holding-heart": {
+        "character": "\uf4be",
+        "searchterms": [
+            "carry",
+            "charity",
+            "gift",
+            "lift",
+            "package",
+            "hand-holding-heart"
+        ]
+    },
+    "hand-holding-usd": {
+        "character": "\uf4c0",
+        "searchterms": [
+            "$",
+            "carry",
+            "dollar sign",
+            "donation",
+            "giving",
+            "lift",
+            "money",
+            "price",
+            "hand-holding-usd"
+        ]
+    },
+    "hand-lizard": {
+        "character": "\uf258",
+        "searchterms": [
+            "game",
+            "roshambo",
+            "hand-lizard",
+            "hand-lizard-o"
+        ]
+    },
+    "hand-lizard-o": {
+        "character": "\uf258",
+        "searchterms": [
+            "game",
+            "roshambo",
+            "hand-lizard",
+            "hand-lizard-o"
+        ]
+    },
+    "hand-middle-finger": {
+        "character": "\uf806",
+        "searchterms": [
+            "flip the bird",
+            "gesture",
+            "hate",
+            "rude",
+            "hand-middle-finger"
+        ]
+    },
+    "hand-o-down": {
+        "character": "\uf0a7",
+        "searchterms": [
+            "finger",
+            "hand-o-down",
+            "point",
+            "hand-point-down"
+        ]
+    },
+    "hand-o-left": {
+        "character": "\uf0a5",
+        "searchterms": [
+            "back",
+            "finger",
+            "hand-o-left",
+            "left",
+            "point",
+            "previous",
+            "hand-point-left"
+        ]
+    },
+    "hand-o-right": {
+        "character": "\uf0a4",
+        "searchterms": [
+            "finger",
+            "forward",
+            "hand-o-right",
+            "next",
+            "point",
+            "right",
+            "hand-point-right"
+        ]
+    },
+    "hand-o-up": {
+        "character": "\uf0a6",
+        "searchterms": [
+            "finger",
+            "hand-o-up",
+            "point",
+            "hand-point-up"
+        ]
+    },
+    "hand-paper": {
+        "character": "\uf256",
+        "searchterms": [
+            "game",
+            "halt",
+            "roshambo",
+            "stop",
+            "hand-paper",
+            "hand-paper-o",
+            "hand-stop-o"
+        ]
+    },
+    "hand-paper-o": {
+        "character": "\uf256",
+        "searchterms": [
+            "game",
+            "halt",
+            "roshambo",
+            "stop",
+            "hand-paper",
+            "hand-paper-o",
+            "hand-stop-o"
+        ]
+    },
+    "hand-peace": {
+        "character": "\uf25b",
+        "searchterms": [
+            "rest",
+            "truce",
+            "hand-peace",
+            "hand-peace-o"
+        ]
+    },
+    "hand-peace-o": {
+        "character": "\uf25b",
+        "searchterms": [
+            "rest",
+            "truce",
+            "hand-peace",
+            "hand-peace-o"
+        ]
+    },
+    "hand-point-down": {
+        "character": "\uf0a7",
+        "searchterms": [
+            "finger",
+            "hand-o-down",
+            "point",
+            "hand-point-down"
+        ]
+    },
+    "hand-point-left": {
+        "character": "\uf0a5",
+        "searchterms": [
+            "back",
+            "finger",
+            "hand-o-left",
+            "left",
+            "point",
+            "previous",
+            "hand-point-left"
+        ]
+    },
+    "hand-point-right": {
+        "character": "\uf0a4",
+        "searchterms": [
+            "finger",
+            "forward",
+            "hand-o-right",
+            "next",
+            "point",
+            "right",
+            "hand-point-right"
+        ]
+    },
+    "hand-point-up": {
+        "character": "\uf0a6",
+        "searchterms": [
+            "finger",
+            "hand-o-up",
+            "point",
+            "hand-point-up"
+        ]
+    },
+    "hand-pointer": {
+        "character": "\uf25a",
+        "searchterms": [
+            "arrow",
+            "cursor",
+            "select",
+            "hand-pointer",
+            "hand-pointer-o"
+        ]
+    },
+    "hand-pointer-o": {
+        "character": "\uf25a",
+        "searchterms": [
+            "arrow",
+            "cursor",
+            "select",
+            "hand-pointer",
+            "hand-pointer-o"
+        ]
+    },
+    "hand-rock": {
+        "character": "\uf255",
+        "searchterms": [
+            "fist",
+            "game",
+            "roshambo",
+            "hand-rock",
+            "hand-rock-o",
+            "hand-grab-o"
+        ]
+    },
+    "hand-rock-o": {
+        "character": "\uf255",
+        "searchterms": [
+            "fist",
+            "game",
+            "roshambo",
+            "hand-rock",
+            "hand-rock-o",
+            "hand-grab-o"
+        ]
+    },
+    "hand-scissors": {
+        "character": "\uf257",
+        "searchterms": [
+            "cut",
+            "game",
+            "roshambo",
+            "hand-scissors",
+            "hand-scissors-o"
+        ]
+    },
+    "hand-scissors-o": {
+        "character": "\uf257",
+        "searchterms": [
+            "cut",
+            "game",
+            "roshambo",
+            "hand-scissors",
+            "hand-scissors-o"
+        ]
+    },
+    "hand-spock": {
+        "character": "\uf259",
+        "searchterms": [
+            "live long",
+            "prosper",
+            "salute",
+            "star trek",
+            "vulcan",
+            "hand-spock",
+            "hand-spock-o"
+        ]
+    },
+    "hand-spock-o": {
+        "character": "\uf259",
+        "searchterms": [
+            "live long",
+            "prosper",
+            "salute",
+            "star trek",
+            "vulcan",
+            "hand-spock",
+            "hand-spock-o"
+        ]
+    },
+    "hand-stop-o": {
+        "character": "\uf256",
+        "searchterms": [
+            "game",
+            "halt",
+            "roshambo",
+            "stop",
+            "hand-paper",
+            "hand-paper-o",
+            "hand-stop-o"
+        ]
+    },
+    "hands": {
+        "character": "\uf4c2",
+        "searchterms": [
+            "carry",
+            "hold",
+            "lift",
+            "hands"
+        ]
+    },
+    "hands-helping": {
+        "character": "\uf4c4",
+        "searchterms": [
+            "aid",
+            "assistance",
+            "handshake",
+            "partnership",
+            "volunteering",
+            "hands-helping"
+        ]
+    },
+    "handshake": {
+        "character": "\uf2b5",
+        "searchterms": [
+            "agreement",
+            "greeting",
+            "meeting",
+            "partnership",
+            "handshake",
+            "handshake-o"
+        ]
+    },
+    "handshake-o": {
+        "character": "\uf2b5",
+        "searchterms": [
+            "agreement",
+            "greeting",
+            "meeting",
+            "partnership",
+            "handshake",
+            "handshake-o"
+        ]
+    },
+    "hanukiah": {
+        "character": "\uf6e6",
+        "searchterms": [
+            "candle",
+            "hanukkah",
+            "jewish",
+            "judaism",
+            "light",
+            "hanukiah"
+        ]
+    },
+    "hard-hat": {
+        "character": "\uf807",
+        "searchterms": [
+            "construction",
+            "hardhat",
+            "helmet",
+            "safety",
+            "hard-hat"
+        ]
+    },
+    "hard-of-hearing": {
+        "character": "\uf2a4",
+        "searchterms": [
+            "ear",
+            "hearing",
+            "sign language",
+            "deaf",
+            "deafness",
+            "hard-of-hearing"
+        ]
+    },
+    "hashtag": {
+        "character": "\uf292",
+        "searchterms": [
+            "Twitter",
+            "instagram",
+            "pound",
+            "social media",
+            "tag",
+            "hashtag"
+        ]
+    },
+    "hat-cowboy": {
+        "character": "\uf8c0",
+        "searchterms": [
+            "buckaroo",
+            "horse",
+            "jackeroo",
+            "john b.",
+            "old west",
+            "pardner",
+            "ranch",
+            "rancher",
+            "rodeo",
+            "western",
+            "wrangler",
+            "hat-cowboy"
+        ]
+    },
+    "hat-cowboy-side": {
+        "character": "\uf8c1",
+        "searchterms": [
+            "buckaroo",
+            "horse",
+            "jackeroo",
+            "john b.",
+            "old west",
+            "pardner",
+            "ranch",
+            "rancher",
+            "rodeo",
+            "western",
+            "wrangler",
+            "hat-cowboy-side"
+        ]
+    },
+    "hat-wizard": {
+        "character": "\uf6e8",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "accessory",
+            "buckle",
+            "clothing",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "halloween",
+            "head",
+            "holiday",
+            "mage",
+            "magic",
+            "pointy",
+            "witch",
+            "hat-wizard"
+        ]
+    },
+    "haykal": {
+        "character": "\uf666",
+        "searchterms": [
+            "bahai",
+            "bah\u00e1'\u00ed",
+            "star",
+            "haykal"
+        ]
+    },
+    "hdd": {
+        "character": "\uf0a0",
+        "searchterms": [
+            "cpu",
+            "hard drive",
+            "harddrive",
+            "machine",
+            "save",
+            "storage",
+            "hdd",
+            "hdd-o"
+        ]
+    },
+    "hdd-o": {
+        "character": "\uf0a0",
+        "searchterms": [
+            "cpu",
+            "hard drive",
+            "harddrive",
+            "machine",
+            "save",
+            "storage",
+            "hdd",
+            "hdd-o"
+        ]
+    },
+    "header": {
+        "character": "\uf1dc",
+        "searchterms": [
+            "format",
+            "header",
+            "text",
+            "title",
+            "heading"
+        ]
+    },
+    "heading": {
+        "character": "\uf1dc",
+        "searchterms": [
+            "format",
+            "header",
+            "text",
+            "title",
+            "heading"
+        ]
+    },
+    "headphones": {
+        "character": "\uf025",
+        "searchterms": [
+            "audio",
+            "listen",
+            "music",
+            "sound",
+            "speaker",
+            "headphones"
+        ]
+    },
+    "headphones-alt": {
+        "character": "\uf58f",
+        "searchterms": [
+            "audio",
+            "listen",
+            "music",
+            "sound",
+            "speaker",
+            "headphones-alt"
+        ]
+    },
+    "headset": {
+        "character": "\uf590",
+        "searchterms": [
+            "audio",
+            "gamer",
+            "gaming",
+            "listen",
+            "live chat",
+            "microphone",
+            "shot caller",
+            "sound",
+            "support",
+            "telemarketer",
+            "headset"
+        ]
+    },
+    "heart": {
+        "character": "\uf004",
+        "searchterms": [
+            "favorite",
+            "like",
+            "love",
+            "relationship",
+            "valentine",
+            "heart",
+            "heart-o"
+        ]
+    },
+    "heart-broken": {
+        "character": "\uf7a9",
+        "searchterms": [
+            "breakup",
+            "crushed",
+            "dislike",
+            "dumped",
+            "grief",
+            "love",
+            "lovesick",
+            "relationship",
+            "sad",
+            "heart-broken"
+        ]
+    },
+    "heart-o": {
+        "character": "\uf004",
+        "searchterms": [
+            "favorite",
+            "like",
+            "love",
+            "relationship",
+            "valentine",
+            "heart",
+            "heart-o"
+        ]
+    },
+    "heartbeat": {
+        "character": "\uf21e",
+        "searchterms": [
+            "ekg",
+            "electrocardiogram",
+            "health",
+            "lifeline",
+            "vital signs",
+            "heartbeat"
+        ]
+    },
+    "helicopter": {
+        "character": "\uf533",
+        "searchterms": [
+            "airwolf",
+            "apache",
+            "chopper",
+            "flight",
+            "fly",
+            "travel",
+            "helicopter"
+        ]
+    },
+    "highlighter": {
+        "character": "\uf591",
+        "searchterms": [
+            "edit",
+            "marker",
+            "sharpie",
+            "update",
+            "write",
+            "highlighter"
+        ]
+    },
+    "hiking": {
+        "character": "\uf6ec",
+        "searchterms": [
+            "activity",
+            "backpack",
+            "fall",
+            "fitness",
+            "outdoors",
+            "person",
+            "seasonal",
+            "walking",
+            "hiking"
+        ]
+    },
+    "hippo": {
+        "character": "\uf6ed",
+        "searchterms": [
+            "animal",
+            "fauna",
+            "hippopotamus",
+            "hungry",
+            "mammal",
+            "hippo"
+        ]
+    },
+    "hips": {
+        "character": "\uf452",
+        "searchterms": [
+            "hips"
+        ]
+    },
+    "hire-a-helper": {
+        "character": "\uf3b0",
+        "searchterms": [
+            "hire-a-helper"
+        ]
+    },
+    "history": {
+        "character": "\uf1da",
+        "searchterms": [
+            "Rewind",
+            "clock",
+            "reverse",
+            "time",
+            "time machine",
+            "history"
+        ]
+    },
+    "hockey-puck": {
+        "character": "\uf453",
+        "searchterms": [
+            "ice",
+            "nhl",
+            "sport",
+            "hockey-puck"
+        ]
+    },
+    "holly-berry": {
+        "character": "\uf7aa",
+        "searchterms": [
+            "catwoman",
+            "christmas",
+            "decoration",
+            "flora",
+            "halle",
+            "holiday",
+            "ororo munroe",
+            "plant",
+            "storm",
+            "xmas",
+            "holly-berry"
+        ]
+    },
+    "home": {
+        "character": "\uf015",
+        "searchterms": [
+            "abode",
+            "building",
+            "house",
+            "main",
+            "home"
+        ]
+    },
+    "hooli": {
+        "character": "\uf427",
+        "searchterms": [
+            "hooli"
+        ]
+    },
+    "hornbill": {
+        "character": "\uf592",
+        "searchterms": [
+            "hornbill"
+        ]
+    },
+    "horse": {
+        "character": "\uf6f0",
+        "searchterms": [
+            "equus",
+            "fauna",
+            "mammmal",
+            "mare",
+            "neigh",
+            "pony",
+            "horse"
+        ]
+    },
+    "horse-head": {
+        "character": "\uf7ab",
+        "searchterms": [
+            "equus",
+            "fauna",
+            "mammmal",
+            "mare",
+            "neigh",
+            "pony",
+            "horse-head"
+        ]
+    },
+    "hospital": {
+        "character": "\uf0f8",
+        "searchterms": [
+            "building",
+            "covid-19",
+            "emergency room",
+            "medical center",
+            "hospital",
+            "hospital-o"
+        ]
+    },
+    "hospital-alt": {
+        "character": "\uf47d",
+        "searchterms": [
+            "building",
+            "covid-19",
+            "emergency room",
+            "medical center",
+            "hospital-alt"
+        ]
+    },
+    "hospital-o": {
+        "character": "\uf0f8",
+        "searchterms": [
+            "building",
+            "covid-19",
+            "emergency room",
+            "medical center",
+            "hospital",
+            "hospital-o"
+        ]
+    },
+    "hospital-symbol": {
+        "character": "\uf47e",
+        "searchterms": [
+            "clinic",
+            "covid-19",
+            "emergency",
+            "map",
+            "hospital-symbol"
+        ]
+    },
+    "hot-tub": {
+        "character": "\uf593",
+        "searchterms": [
+            "bath",
+            "jacuzzi",
+            "massage",
+            "sauna",
+            "spa",
+            "hot-tub"
+        ]
+    },
+    "hotdog": {
+        "character": "\uf80f",
+        "searchterms": [
+            "bun",
+            "chili",
+            "frankfurt",
+            "frankfurter",
+            "kosher",
+            "polish",
+            "sandwich",
+            "sausage",
+            "vienna",
+            "weiner",
+            "hotdog"
+        ]
+    },
+    "hotel": {
+        "character": "\uf594",
+        "searchterms": [
+            "building",
+            "inn",
+            "lodging",
+            "motel",
+            "resort",
+            "travel",
+            "hotel"
+        ]
+    },
+    "hotjar": {
+        "character": "\uf3b1",
+        "searchterms": [
+            "hotjar"
+        ]
+    },
+    "hourglass": {
+        "character": "\uf254",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass",
+            "hourglass-o"
+        ]
+    },
+    "hourglass-1": {
+        "character": "\uf251",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass-start",
+            "hourglass-1"
+        ]
+    },
+    "hourglass-2": {
+        "character": "\uf252",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass-half",
+            "hourglass-2"
+        ]
+    },
+    "hourglass-3": {
+        "character": "\uf253",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass-end",
+            "hourglass-3"
+        ]
+    },
+    "hourglass-end": {
+        "character": "\uf253",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass-end",
+            "hourglass-3"
+        ]
+    },
+    "hourglass-half": {
+        "character": "\uf252",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass-half",
+            "hourglass-2"
+        ]
+    },
+    "hourglass-o": {
+        "character": "\uf254",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass",
+            "hourglass-o"
+        ]
+    },
+    "hourglass-start": {
+        "character": "\uf251",
+        "searchterms": [
+            "hour",
+            "minute",
+            "sand",
+            "stopwatch",
+            "time",
+            "hourglass-start",
+            "hourglass-1"
+        ]
+    },
+    "house-damage": {
+        "character": "\uf6f1",
+        "searchterms": [
+            "building",
+            "devastation",
+            "disaster",
+            "home",
+            "insurance",
+            "house-damage"
+        ]
+    },
+    "houzz": {
+        "character": "\uf27c",
+        "searchterms": [
+            "houzz"
+        ]
+    },
+    "hryvnia": {
+        "character": "\uf6f2",
+        "searchterms": [
+            "currency",
+            "money",
+            "ukraine",
+            "ukrainian",
+            "hryvnia"
+        ]
+    },
+    "html5": {
+        "character": "\uf13b",
+        "searchterms": [
+            "html5"
+        ]
+    },
+    "hubspot": {
+        "character": "\uf3b2",
+        "searchterms": [
+            "hubspot"
+        ]
+    },
+    "i-cursor": {
+        "character": "\uf246",
+        "searchterms": [
+            "editing",
+            "i-beam",
+            "type",
+            "writing",
+            "i-cursor"
+        ]
+    },
+    "ice-cream": {
+        "character": "\uf810",
+        "searchterms": [
+            "chocolate",
+            "cone",
+            "dessert",
+            "frozen",
+            "scoop",
+            "sorbet",
+            "vanilla",
+            "yogurt",
+            "ice-cream"
+        ]
+    },
+    "icicles": {
+        "character": "\uf7ad",
+        "searchterms": [
+            "cold",
+            "frozen",
+            "hanging",
+            "ice",
+            "seasonal",
+            "sharp",
+            "icicles"
+        ]
+    },
+    "icons": {
+        "character": "\uf86d",
+        "searchterms": [
+            "bolt",
+            "emoji",
+            "heart",
+            "image",
+            "music",
+            "photo",
+            "symbols",
+            "icons"
+        ]
+    },
+    "id-badge": {
+        "character": "\uf2c1",
+        "searchterms": [
+            "address",
+            "contact",
+            "identification",
+            "license",
+            "profile",
+            "id-badge"
+        ]
+    },
+    "id-card": {
+        "character": "\uf2c2",
+        "searchterms": [
+            "contact",
+            "demographics",
+            "document",
+            "identification",
+            "issued",
+            "profile",
+            "id-card",
+            "drivers-license",
+            "id-card-o",
+            "drivers-license-o"
+        ]
+    },
+    "id-card-alt": {
+        "character": "\uf47f",
+        "searchterms": [
+            "contact",
+            "demographics",
+            "document",
+            "identification",
+            "issued",
+            "profile",
+            "id-card-alt"
+        ]
+    },
+    "id-card-o": {
+        "character": "\uf2c2",
+        "searchterms": [
+            "contact",
+            "demographics",
+            "document",
+            "identification",
+            "issued",
+            "profile",
+            "id-card",
+            "drivers-license",
+            "id-card-o",
+            "drivers-license-o"
+        ]
+    },
+    "igloo": {
+        "character": "\uf7ae",
+        "searchterms": [
+            "dome",
+            "dwelling",
+            "eskimo",
+            "home",
+            "house",
+            "ice",
+            "snow",
+            "igloo"
+        ]
+    },
+    "ils": {
+        "character": "\uf20b",
+        "searchterms": [
+            "currency",
+            "ils",
+            "money",
+            "shekel-sign",
+            "shekel",
+            "sheqel"
+        ]
+    },
+    "image": {
+        "character": "\uf03e",
+        "searchterms": [
+            "album",
+            "landscape",
+            "photo",
+            "picture",
+            "image",
+            "picture-o"
+        ]
+    },
+    "images": {
+        "character": "\uf302",
+        "searchterms": [
+            "album",
+            "landscape",
+            "photo",
+            "picture",
+            "images"
+        ]
+    },
+    "imdb": {
+        "character": "\uf2d8",
+        "searchterms": [
+            "imdb"
+        ]
+    },
+    "inbox": {
+        "character": "\uf01c",
+        "searchterms": [
+            "archive",
+            "desk",
+            "email",
+            "mail",
+            "message",
+            "inbox"
+        ]
+    },
+    "indent": {
+        "character": "\uf03c",
+        "searchterms": [
+            "align",
+            "justify",
+            "paragraph",
+            "tab",
+            "indent"
+        ]
+    },
+    "industry": {
+        "character": "\uf275",
+        "searchterms": [
+            "building",
+            "factory",
+            "industrial",
+            "manufacturing",
+            "mill",
+            "warehouse",
+            "industry"
+        ]
+    },
+    "infinity": {
+        "character": "\uf534",
+        "searchterms": [
+            "eternity",
+            "forever",
+            "math",
+            "infinity"
+        ]
+    },
+    "info": {
+        "character": "\uf129",
+        "searchterms": [
+            "details",
+            "help",
+            "information",
+            "more",
+            "support",
+            "info"
+        ]
+    },
+    "info-circle": {
+        "character": "\uf05a",
+        "searchterms": [
+            "details",
+            "help",
+            "information",
+            "more",
+            "support",
+            "info-circle"
+        ]
+    },
+    "inr": {
+        "character": "\uf156",
+        "searchterms": [
+            "currency",
+            "indian",
+            "inr",
+            "money",
+            "rupee-sign",
+            "rupee"
+        ]
+    },
+    "instagram": {
+        "character": "\uf16d",
+        "searchterms": [
+            "instagram"
+        ]
+    },
+    "institution": {
+        "character": "\uf19c",
+        "searchterms": [
+            "bank",
+            "building",
+            "college",
+            "higher education - students",
+            "institution",
+            "university"
+        ]
+    },
+    "intercom": {
+        "character": "\uf7af",
+        "searchterms": [
+            "app",
+            "customer",
+            "messenger",
+            "intercom"
+        ]
+    },
+    "internet-explorer": {
+        "character": "\uf26b",
+        "searchterms": [
+            "browser",
+            "ie",
+            "internet-explorer"
+        ]
+    },
+    "intersex": {
+        "character": "\uf224",
+        "searchterms": [
+            "intersex",
+            "transgender"
+        ]
+    },
+    "invision": {
+        "character": "\uf7b0",
+        "searchterms": [
+            "app",
+            "design",
+            "interface",
+            "invision"
+        ]
+    },
+    "ioxhost": {
+        "character": "\uf208",
+        "searchterms": [
+            "ioxhost"
+        ]
+    },
+    "italic": {
+        "character": "\uf033",
+        "searchterms": [
+            "edit",
+            "emphasis",
+            "font",
+            "format",
+            "text",
+            "type",
+            "italic"
+        ]
+    },
+    "itch-io": {
+        "character": "\uf83a",
+        "searchterms": [
+            "itch-io"
+        ]
+    },
+    "itunes": {
+        "character": "\uf3b4",
+        "searchterms": [
+            "itunes"
+        ]
+    },
+    "itunes-note": {
+        "character": "\uf3b5",
+        "searchterms": [
+            "itunes-note"
+        ]
+    },
+    "java": {
+        "character": "\uf4e4",
+        "searchterms": [
+            "java"
+        ]
+    },
+    "jedi": {
+        "character": "\uf669",
+        "searchterms": [
+            "crest",
+            "force",
+            "sith",
+            "skywalker",
+            "star wars",
+            "yoda",
+            "jedi"
+        ]
+    },
+    "jedi-order": {
+        "character": "\uf50e",
+        "searchterms": [
+            "star wars",
+            "jedi-order"
+        ]
+    },
+    "jenkins": {
+        "character": "\uf3b6",
+        "searchterms": [
+            "jenkins"
+        ]
+    },
+    "jira": {
+        "character": "\uf7b1",
+        "searchterms": [
+            "atlassian",
+            "jira"
+        ]
+    },
+    "joget": {
+        "character": "\uf3b7",
+        "searchterms": [
+            "joget"
+        ]
+    },
+    "joint": {
+        "character": "\uf595",
+        "searchterms": [
+            "blunt",
+            "cannabis",
+            "doobie",
+            "drugs",
+            "marijuana",
+            "roach",
+            "smoke",
+            "smoking",
+            "spliff",
+            "joint"
+        ]
+    },
+    "joomla": {
+        "character": "\uf1aa",
+        "searchterms": [
+            "joomla"
+        ]
+    },
+    "journal-whills": {
+        "character": "\uf66a",
+        "searchterms": [
+            "book",
+            "force",
+            "jedi",
+            "sith",
+            "star wars",
+            "yoda",
+            "journal-whills"
+        ]
+    },
+    "jpy": {
+        "character": "\uf157",
+        "searchterms": [
+            "currency",
+            "jpy",
+            "money",
+            "yen-sign",
+            "cny",
+            "rmb",
+            "yen"
+        ]
+    },
+    "js": {
+        "character": "\uf3b8",
+        "searchterms": [
+            "js"
+        ]
+    },
+    "js-square": {
+        "character": "\uf3b9",
+        "searchterms": [
+            "js-square"
+        ]
+    },
+    "jsfiddle": {
+        "character": "\uf1cc",
+        "searchterms": [
+            "jsfiddle"
+        ]
+    },
+    "kaaba": {
+        "character": "\uf66b",
+        "searchterms": [
+            "building",
+            "cube",
+            "islam",
+            "muslim",
+            "kaaba"
+        ]
+    },
+    "kaggle": {
+        "character": "\uf5fa",
+        "searchterms": [
+            "kaggle"
+        ]
+    },
+    "key": {
+        "character": "\uf084",
+        "searchterms": [
+            "lock",
+            "password",
+            "private",
+            "secret",
+            "unlock",
+            "key"
+        ]
+    },
+    "keybase": {
+        "character": "\uf4f5",
+        "searchterms": [
+            "keybase"
+        ]
+    },
+    "keyboard": {
+        "character": "\uf11c",
+        "searchterms": [
+            "accessory",
+            "edit",
+            "input",
+            "text",
+            "type",
+            "write",
+            "keyboard",
+            "keyboard-o"
+        ]
+    },
+    "keyboard-o": {
+        "character": "\uf11c",
+        "searchterms": [
+            "accessory",
+            "edit",
+            "input",
+            "text",
+            "type",
+            "write",
+            "keyboard",
+            "keyboard-o"
+        ]
+    },
+    "keycdn": {
+        "character": "\uf3ba",
+        "searchterms": [
+            "keycdn"
+        ]
+    },
+    "khanda": {
+        "character": "\uf66d",
+        "searchterms": [
+            "chakkar",
+            "sikh",
+            "sikhism",
+            "sword",
+            "khanda"
+        ]
+    },
+    "kickstarter": {
+        "character": "\uf3bb",
+        "searchterms": [
+            "kickstarter"
+        ]
+    },
+    "kickstarter-k": {
+        "character": "\uf3bc",
+        "searchterms": [
+            "kickstarter-k"
+        ]
+    },
+    "kiss": {
+        "character": "\uf596",
+        "searchterms": [
+            "beso",
+            "emoticon",
+            "face",
+            "love",
+            "smooch",
+            "kiss"
+        ]
+    },
+    "kiss-beam": {
+        "character": "\uf597",
+        "searchterms": [
+            "beso",
+            "emoticon",
+            "face",
+            "love",
+            "smooch",
+            "kiss-beam"
+        ]
+    },
+    "kiss-wink-heart": {
+        "character": "\uf598",
+        "searchterms": [
+            "beso",
+            "emoticon",
+            "face",
+            "love",
+            "smooch",
+            "kiss-wink-heart"
+        ]
+    },
+    "kiwi-bird": {
+        "character": "\uf535",
+        "searchterms": [
+            "bird",
+            "fauna",
+            "new zealand",
+            "kiwi-bird"
+        ]
+    },
+    "korvue": {
+        "character": "\uf42f",
+        "searchterms": [
+            "korvue"
+        ]
+    },
+    "krw": {
+        "character": "\uf159",
+        "searchterms": [
+            "currency",
+            "krw",
+            "money",
+            "won-sign",
+            "won"
+        ]
+    },
+    "landmark": {
+        "character": "\uf66f",
+        "searchterms": [
+            "building",
+            "historic",
+            "memorable",
+            "monument",
+            "politics",
+            "landmark"
+        ]
+    },
+    "language": {
+        "character": "\uf1ab",
+        "searchterms": [
+            "dialect",
+            "idiom",
+            "localize",
+            "speech",
+            "translate",
+            "vernacular",
+            "language"
+        ]
+    },
+    "laptop": {
+        "character": "\uf109",
+        "searchterms": [
+            "computer",
+            "cpu",
+            "dell",
+            "demo",
+            "device",
+            "mac",
+            "macbook",
+            "machine",
+            "pc",
+            "laptop"
+        ]
+    },
+    "laptop-code": {
+        "character": "\uf5fc",
+        "searchterms": [
+            "computer",
+            "cpu",
+            "dell",
+            "demo",
+            "develop",
+            "device",
+            "mac",
+            "macbook",
+            "machine",
+            "pc",
+            "laptop-code"
+        ]
+    },
+    "laptop-medical": {
+        "character": "\uf812",
+        "searchterms": [
+            "computer",
+            "device",
+            "ehr",
+            "electronic health records",
+            "history",
+            "laptop-medical"
+        ]
+    },
+    "laravel": {
+        "character": "\uf3bd",
+        "searchterms": [
+            "laravel"
+        ]
+    },
+    "lastfm": {
+        "character": "\uf202",
+        "searchterms": [
+            "lastfm"
+        ]
+    },
+    "lastfm-square": {
+        "character": "\uf203",
+        "searchterms": [
+            "lastfm-square"
+        ]
+    },
+    "laugh": {
+        "character": "\uf599",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "laugh",
+            "smile"
+        ]
+    },
+    "laugh-beam": {
+        "character": "\uf59a",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "happy",
+            "smile",
+            "laugh-beam"
+        ]
+    },
+    "laugh-squint": {
+        "character": "\uf59b",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "happy",
+            "smile",
+            "laugh-squint"
+        ]
+    },
+    "laugh-wink": {
+        "character": "\uf59c",
+        "searchterms": [
+            "LOL",
+            "emoticon",
+            "face",
+            "happy",
+            "smile",
+            "laugh-wink"
+        ]
+    },
+    "layer-group": {
+        "character": "\uf5fd",
+        "searchterms": [
+            "arrange",
+            "develop",
+            "layers",
+            "map",
+            "stack",
+            "layer-group"
+        ]
+    },
+    "leaf": {
+        "character": "\uf06c",
+        "searchterms": [
+            "eco",
+            "flora",
+            "nature",
+            "plant",
+            "vegan",
+            "leaf"
+        ]
+    },
+    "leanpub": {
+        "character": "\uf212",
+        "searchterms": [
+            "leanpub"
+        ]
+    },
+    "legal": {
+        "character": "\uf0e3",
+        "searchterms": [
+            "hammer",
+            "judge",
+            "law",
+            "lawyer",
+            "opinion",
+            "gavel",
+            "legal"
+        ]
+    },
+    "lemon": {
+        "character": "\uf094",
+        "searchterms": [
+            "citrus",
+            "lemonade",
+            "lime",
+            "tart",
+            "lemon",
+            "lemon-o"
+        ]
+    },
+    "lemon-o": {
+        "character": "\uf094",
+        "searchterms": [
+            "citrus",
+            "lemonade",
+            "lime",
+            "tart",
+            "lemon",
+            "lemon-o"
+        ]
+    },
+    "less": {
+        "character": "\uf41d",
+        "searchterms": [
+            "less"
+        ]
+    },
+    "less-than": {
+        "character": "\uf536",
+        "searchterms": [
+            "arithmetic",
+            "compare",
+            "math",
+            "less-than"
+        ]
+    },
+    "less-than-equal": {
+        "character": "\uf537",
+        "searchterms": [
+            "arithmetic",
+            "compare",
+            "math",
+            "less-than-equal"
+        ]
+    },
+    "level-down": {
+        "character": "\uf3be",
+        "searchterms": [
+            "arrow",
+            "level-down",
+            "level-down-alt"
+        ]
+    },
+    "level-down-alt": {
+        "character": "\uf3be",
+        "searchterms": [
+            "arrow",
+            "level-down",
+            "level-down-alt"
+        ]
+    },
+    "level-up": {
+        "character": "\uf3bf",
+        "searchterms": [
+            "arrow",
+            "level-up",
+            "level-up-alt"
+        ]
+    },
+    "level-up-alt": {
+        "character": "\uf3bf",
+        "searchterms": [
+            "arrow",
+            "level-up",
+            "level-up-alt"
+        ]
+    },
+    "life-bouy": {
+        "character": "\uf1cd",
+        "searchterms": [
+            "coast guard",
+            "help",
+            "overboard",
+            "save",
+            "support",
+            "life-ring",
+            "life-bouy",
+            "life-buoy",
+            "life-saver"
+        ]
+    },
+    "life-buoy": {
+        "character": "\uf1cd",
+        "searchterms": [
+            "coast guard",
+            "help",
+            "overboard",
+            "save",
+            "support",
+            "life-ring",
+            "life-bouy",
+            "life-buoy",
+            "life-saver"
+        ]
+    },
+    "life-ring": {
+        "character": "\uf1cd",
+        "searchterms": [
+            "coast guard",
+            "help",
+            "overboard",
+            "save",
+            "support",
+            "life-ring",
+            "life-bouy",
+            "life-buoy",
+            "life-saver"
+        ]
+    },
+    "life-saver": {
+        "character": "\uf1cd",
+        "searchterms": [
+            "coast guard",
+            "help",
+            "overboard",
+            "save",
+            "support",
+            "life-ring",
+            "life-bouy",
+            "life-buoy",
+            "life-saver"
+        ]
+    },
+    "lightbulb": {
+        "character": "\uf0eb",
+        "searchterms": [
+            "energy",
+            "idea",
+            "inspiration",
+            "light",
+            "lightbulb",
+            "lightbulb-o"
+        ]
+    },
+    "lightbulb-o": {
+        "character": "\uf0eb",
+        "searchterms": [
+            "energy",
+            "idea",
+            "inspiration",
+            "light",
+            "lightbulb",
+            "lightbulb-o"
+        ]
+    },
+    "line": {
+        "character": "\uf3c0",
+        "searchterms": [
+            "line"
+        ]
+    },
+    "line-chart": {
+        "character": "\uf201",
+        "searchterms": [
+            "activity",
+            "analytics",
+            "chart",
+            "dashboard",
+            "gain",
+            "graph",
+            "increase",
+            "line",
+            "chart-line",
+            "line-chart"
+        ]
+    },
+    "link": {
+        "character": "\uf0c1",
+        "searchterms": [
+            "attach",
+            "attachment",
+            "chain",
+            "connect",
+            "link"
+        ]
+    },
+    "linkedin": {
+        "character": "\uf08c",
+        "searchterms": [
+            "linkedin-square",
+            "linkedin"
+        ]
+    },
+    "linkedin-in": {
+        "character": "\uf0e1",
+        "searchterms": [
+            "linkedin",
+            "linkedin-in"
+        ]
+    },
+    "linkedin-square": {
+        "character": "\uf08c",
+        "searchterms": [
+            "linkedin-square",
+            "linkedin"
+        ]
+    },
+    "linode": {
+        "character": "\uf2b8",
+        "searchterms": [
+            "linode"
+        ]
+    },
+    "linux": {
+        "character": "\uf17c",
+        "searchterms": [
+            "tux",
+            "linux"
+        ]
+    },
+    "lira-sign": {
+        "character": "\uf195",
+        "searchterms": [
+            "currency",
+            "money",
+            "try",
+            "turkish",
+            "lira-sign",
+            "turkish-lira"
+        ]
+    },
+    "list": {
+        "character": "\uf03a",
+        "searchterms": [
+            "checklist",
+            "completed",
+            "done",
+            "finished",
+            "ol",
+            "todo",
+            "ul",
+            "list"
+        ]
+    },
+    "list-alt": {
+        "character": "\uf022",
+        "searchterms": [
+            "checklist",
+            "completed",
+            "done",
+            "finished",
+            "ol",
+            "todo",
+            "ul",
+            "list-alt"
+        ]
+    },
+    "list-ol": {
+        "character": "\uf0cb",
+        "searchterms": [
+            "checklist",
+            "completed",
+            "done",
+            "finished",
+            "numbers",
+            "ol",
+            "todo",
+            "ul",
+            "list-ol"
+        ]
+    },
+    "list-ul": {
+        "character": "\uf0ca",
+        "searchterms": [
+            "checklist",
+            "completed",
+            "done",
+            "finished",
+            "ol",
+            "todo",
+            "ul",
+            "list-ul"
+        ]
+    },
+    "location-arrow": {
+        "character": "\uf124",
+        "searchterms": [
+            "address",
+            "compass",
+            "coordinate",
+            "direction",
+            "gps",
+            "map",
+            "navigation",
+            "place",
+            "location-arrow"
+        ]
+    },
+    "lock": {
+        "character": "\uf023",
+        "searchterms": [
+            "admin",
+            "lock",
+            "open",
+            "password",
+            "private",
+            "protect",
+            "security"
+        ]
+    },
+    "lock-open": {
+        "character": "\uf3c1",
+        "searchterms": [
+            "admin",
+            "lock",
+            "open",
+            "password",
+            "private",
+            "protect",
+            "security",
+            "lock-open"
+        ]
+    },
+    "long-arrow-alt-down": {
+        "character": "\uf309",
+        "searchterms": [
+            "download",
+            "long-arrow-down",
+            "long-arrow-alt-down"
+        ]
+    },
+    "long-arrow-alt-left": {
+        "character": "\uf30a",
+        "searchterms": [
+            "back",
+            "long-arrow-left",
+            "previous",
+            "long-arrow-alt-left"
+        ]
+    },
+    "long-arrow-alt-right": {
+        "character": "\uf30b",
+        "searchterms": [
+            "forward",
+            "long-arrow-right",
+            "next",
+            "long-arrow-alt-right"
+        ]
+    },
+    "long-arrow-alt-up": {
+        "character": "\uf30c",
+        "searchterms": [
+            "long-arrow-up",
+            "upload",
+            "long-arrow-alt-up"
+        ]
+    },
+    "long-arrow-down": {
+        "character": "\uf309",
+        "searchterms": [
+            "download",
+            "long-arrow-down",
+            "long-arrow-alt-down"
+        ]
+    },
+    "long-arrow-left": {
+        "character": "\uf30a",
+        "searchterms": [
+            "back",
+            "long-arrow-left",
+            "previous",
+            "long-arrow-alt-left"
+        ]
+    },
+    "long-arrow-right": {
+        "character": "\uf30b",
+        "searchterms": [
+            "forward",
+            "long-arrow-right",
+            "next",
+            "long-arrow-alt-right"
+        ]
+    },
+    "long-arrow-up": {
+        "character": "\uf30c",
+        "searchterms": [
+            "long-arrow-up",
+            "upload",
+            "long-arrow-alt-up"
+        ]
+    },
+    "low-vision": {
+        "character": "\uf2a8",
+        "searchterms": [
+            "blind",
+            "eye",
+            "sight",
+            "low-vision"
+        ]
+    },
+    "luggage-cart": {
+        "character": "\uf59d",
+        "searchterms": [
+            "bag",
+            "baggage",
+            "suitcase",
+            "travel",
+            "luggage-cart"
+        ]
+    },
+    "lyft": {
+        "character": "\uf3c3",
+        "searchterms": [
+            "lyft"
+        ]
+    },
+    "magento": {
+        "character": "\uf3c4",
+        "searchterms": [
+            "magento"
+        ]
+    },
+    "magic": {
+        "character": "\uf0d0",
+        "searchterms": [
+            "autocomplete",
+            "automatic",
+            "mage",
+            "magic",
+            "spell",
+            "wand",
+            "witch",
+            "wizard"
+        ]
+    },
+    "magnet": {
+        "character": "\uf076",
+        "searchterms": [
+            "Attract",
+            "lodestone",
+            "tool",
+            "magnet"
+        ]
+    },
+    "mail-bulk": {
+        "character": "\uf674",
+        "searchterms": [
+            "archive",
+            "envelope",
+            "letter",
+            "post office",
+            "postal",
+            "postcard",
+            "send",
+            "stamp",
+            "usps",
+            "mail-bulk"
+        ]
+    },
+    "mail-forward": {
+        "character": "\uf064",
+        "searchterms": [
+            "forward",
+            "save",
+            "send",
+            "social",
+            "share",
+            "mail-forward"
+        ]
+    },
+    "mail-reply": {
+        "character": "\uf3e5",
+        "searchterms": [
+            "mail",
+            "message",
+            "respond",
+            "reply",
+            "mail-reply"
+        ]
+    },
+    "mail-reply-all": {
+        "character": "\uf122",
+        "searchterms": [
+            "mail",
+            "message",
+            "respond",
+            "reply-all",
+            "mail-reply-all"
+        ]
+    },
+    "mailchimp": {
+        "character": "\uf59e",
+        "searchterms": [
+            "mailchimp"
+        ]
+    },
+    "male": {
+        "character": "\uf183",
+        "searchterms": [
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user",
+            "male"
+        ]
+    },
+    "mandalorian": {
+        "character": "\uf50f",
+        "searchterms": [
+            "mandalorian"
+        ]
+    },
+    "map": {
+        "character": "\uf279",
+        "searchterms": [
+            "address",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "navigation",
+            "paper",
+            "pin",
+            "place",
+            "point of interest",
+            "position",
+            "route",
+            "travel",
+            "map-o"
+        ]
+    },
+    "map-marked": {
+        "character": "\uf59f",
+        "searchterms": [
+            "address",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "navigation",
+            "paper",
+            "pin",
+            "place",
+            "point of interest",
+            "position",
+            "route",
+            "travel",
+            "map-marked"
+        ]
+    },
+    "map-marked-alt": {
+        "character": "\uf5a0",
+        "searchterms": [
+            "address",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "navigation",
+            "paper",
+            "pin",
+            "place",
+            "point of interest",
+            "position",
+            "route",
+            "travel",
+            "map-marked-alt"
+        ]
+    },
+    "map-marker": {
+        "character": "\uf041",
+        "searchterms": [
+            "address",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "navigation",
+            "paper",
+            "pin",
+            "place",
+            "point of interest",
+            "position",
+            "route",
+            "travel",
+            "map-marker"
+        ]
+    },
+    "map-marker-alt": {
+        "character": "\uf3c5",
+        "searchterms": [
+            "address",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "navigation",
+            "paper",
+            "pin",
+            "place",
+            "point of interest",
+            "position",
+            "route",
+            "travel",
+            "map-marker-alt"
+        ]
+    },
+    "map-o": {
+        "character": "\uf279",
+        "searchterms": [
+            "address",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "navigation",
+            "paper",
+            "pin",
+            "place",
+            "point of interest",
+            "position",
+            "route",
+            "travel",
+            "map-o"
+        ]
+    },
+    "map-pin": {
+        "character": "\uf276",
+        "searchterms": [
+            "address",
+            "agree",
+            "coordinates",
+            "destination",
+            "gps",
+            "localize",
+            "location",
+            "map",
+            "marker",
+            "navigation",
+            "pin",
+            "place",
+            "position",
+            "travel",
+            "map-pin"
+        ]
+    },
+    "map-signs": {
+        "character": "\uf277",
+        "searchterms": [
+            "directions",
+            "directory",
+            "map",
+            "signage",
+            "wayfinding",
+            "map-signs"
+        ]
+    },
+    "markdown": {
+        "character": "\uf60f",
+        "searchterms": [
+            "markdown"
+        ]
+    },
+    "marker": {
+        "character": "\uf5a1",
+        "searchterms": [
+            "design",
+            "edit",
+            "sharpie",
+            "update",
+            "write",
+            "marker"
+        ]
+    },
+    "mars": {
+        "character": "\uf222",
+        "searchterms": [
+            "male",
+            "mars"
+        ]
+    },
+    "mars-double": {
+        "character": "\uf227",
+        "searchterms": [
+            "mars-double"
+        ]
+    },
+    "mars-stroke": {
+        "character": "\uf229",
+        "searchterms": [
+            "mars-stroke"
+        ]
+    },
+    "mars-stroke-h": {
+        "character": "\uf22b",
+        "searchterms": [
+            "mars-stroke-h"
+        ]
+    },
+    "mars-stroke-v": {
+        "character": "\uf22a",
+        "searchterms": [
+            "mars-stroke-v"
+        ]
+    },
+    "mask": {
+        "character": "\uf6fa",
+        "searchterms": [
+            "carnivale",
+            "costume",
+            "disguise",
+            "halloween",
+            "secret",
+            "super hero",
+            "mask"
+        ]
+    },
+    "mastodon": {
+        "character": "\uf4f6",
+        "searchterms": [
+            "mastodon"
+        ]
+    },
+    "maxcdn": {
+        "character": "\uf136",
+        "searchterms": [
+            "maxcdn"
+        ]
+    },
+    "mdb": {
+        "character": "\uf8ca",
+        "searchterms": [
+            "mdb"
+        ]
+    },
+    "meanpath": {
+        "character": "\uf2b4",
+        "searchterms": [
+            "meanpath",
+            "font-awesome",
+            "fa"
+        ]
+    },
+    "medal": {
+        "character": "\uf5a2",
+        "searchterms": [
+            "award",
+            "ribbon",
+            "star",
+            "trophy",
+            "medal"
+        ]
+    },
+    "medapps": {
+        "character": "\uf3c6",
+        "searchterms": [
+            "medapps"
+        ]
+    },
+    "medium": {
+        "character": "\uf23a",
+        "searchterms": [
+            "medium"
+        ]
+    },
+    "medium-m": {
+        "character": "\uf3c7",
+        "searchterms": [
+            "medium-m"
+        ]
+    },
+    "medkit": {
+        "character": "\uf0fa",
+        "searchterms": [
+            "first aid",
+            "firstaid",
+            "health",
+            "help",
+            "support",
+            "medkit"
+        ]
+    },
+    "medrt": {
+        "character": "\uf3c8",
+        "searchterms": [
+            "medrt"
+        ]
+    },
+    "meetup": {
+        "character": "\uf2e0",
+        "searchterms": [
+            "meetup"
+        ]
+    },
+    "megaport": {
+        "character": "\uf5a3",
+        "searchterms": [
+            "megaport"
+        ]
+    },
+    "meh": {
+        "character": "\uf11a",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "neutral",
+            "rating",
+            "meh",
+            "meh-o"
+        ]
+    },
+    "meh-blank": {
+        "character": "\uf5a4",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "neutral",
+            "rating",
+            "meh-blank"
+        ]
+    },
+    "meh-o": {
+        "character": "\uf11a",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "neutral",
+            "rating",
+            "meh",
+            "meh-o"
+        ]
+    },
+    "meh-rolling-eyes": {
+        "character": "\uf5a5",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "neutral",
+            "rating",
+            "meh-rolling-eyes"
+        ]
+    },
+    "memory": {
+        "character": "\uf538",
+        "searchterms": [
+            "DIMM",
+            "RAM",
+            "hardware",
+            "storage",
+            "technology",
+            "memory"
+        ]
+    },
+    "mendeley": {
+        "character": "\uf7b3",
+        "searchterms": [
+            "mendeley"
+        ]
+    },
+    "menorah": {
+        "character": "\uf676",
+        "searchterms": [
+            "candle",
+            "hanukkah",
+            "jewish",
+            "judaism",
+            "light",
+            "menorah"
+        ]
+    },
+    "mercury": {
+        "character": "\uf223",
+        "searchterms": [
+            "transgender",
+            "mercury"
+        ]
+    },
+    "meteor": {
+        "character": "\uf753",
+        "searchterms": [
+            "armageddon",
+            "asteroid",
+            "comet",
+            "shooting star",
+            "space",
+            "meteor"
+        ]
+    },
+    "microchip": {
+        "character": "\uf2db",
+        "searchterms": [
+            "cpu",
+            "hardware",
+            "processor",
+            "technology",
+            "microchip"
+        ]
+    },
+    "microphone": {
+        "character": "\uf130",
+        "searchterms": [
+            "audio",
+            "podcast",
+            "record",
+            "sing",
+            "sound",
+            "voice",
+            "microphone"
+        ]
+    },
+    "microphone-alt": {
+        "character": "\uf3c9",
+        "searchterms": [
+            "audio",
+            "podcast",
+            "record",
+            "sing",
+            "sound",
+            "voice",
+            "microphone-alt"
+        ]
+    },
+    "microphone-alt-slash": {
+        "character": "\uf539",
+        "searchterms": [
+            "audio",
+            "disable",
+            "mute",
+            "podcast",
+            "record",
+            "sing",
+            "sound",
+            "voice",
+            "microphone-alt-slash"
+        ]
+    },
+    "microphone-slash": {
+        "character": "\uf131",
+        "searchterms": [
+            "audio",
+            "disable",
+            "mute",
+            "podcast",
+            "record",
+            "sing",
+            "sound",
+            "voice",
+            "microphone-slash"
+        ]
+    },
+    "microscope": {
+        "character": "\uf610",
+        "searchterms": [
+            "covid-19",
+            "electron",
+            "lens",
+            "optics",
+            "science",
+            "shrink",
+            "microscope"
+        ]
+    },
+    "microsoft": {
+        "character": "\uf3ca",
+        "searchterms": [
+            "microsoft"
+        ]
+    },
+    "minus": {
+        "character": "\uf068",
+        "searchterms": [
+            "collapse",
+            "delete",
+            "hide",
+            "minify",
+            "negative",
+            "remove",
+            "trash",
+            "minus"
+        ]
+    },
+    "minus-circle": {
+        "character": "\uf056",
+        "searchterms": [
+            "delete",
+            "hide",
+            "negative",
+            "remove",
+            "shape",
+            "trash",
+            "minus-circle"
+        ]
+    },
+    "minus-square": {
+        "character": "\uf146",
+        "searchterms": [
+            "collapse",
+            "delete",
+            "hide",
+            "minify",
+            "negative",
+            "remove",
+            "shape",
+            "trash",
+            "minus-square",
+            "minus-square-o"
+        ]
+    },
+    "minus-square-o": {
+        "character": "\uf146",
+        "searchterms": [
+            "collapse",
+            "delete",
+            "hide",
+            "minify",
+            "negative",
+            "remove",
+            "shape",
+            "trash",
+            "minus-square",
+            "minus-square-o"
+        ]
+    },
+    "mitten": {
+        "character": "\uf7b5",
+        "searchterms": [
+            "clothing",
+            "cold",
+            "glove",
+            "hands",
+            "knitted",
+            "seasonal",
+            "warmth",
+            "mitten"
+        ]
+    },
+    "mix": {
+        "character": "\uf3cb",
+        "searchterms": [
+            "mix"
+        ]
+    },
+    "mixcloud": {
+        "character": "\uf289",
+        "searchterms": [
+            "mixcloud"
+        ]
+    },
+    "mizuni": {
+        "character": "\uf3cc",
+        "searchterms": [
+            "mizuni"
+        ]
+    },
+    "mobile": {
+        "character": "\uf10b",
+        "searchterms": [
+            "apple",
+            "call",
+            "cell phone",
+            "cellphone",
+            "device",
+            "iphone",
+            "number",
+            "screen",
+            "telephone",
+            "mobile"
+        ]
+    },
+    "mobile-alt": {
+        "character": "\uf3cd",
+        "searchterms": [
+            "apple",
+            "call",
+            "cell phone",
+            "cellphone",
+            "device",
+            "iphone",
+            "number",
+            "screen",
+            "telephone",
+            "mobile-alt",
+            "mobile-phone"
+        ]
+    },
+    "mobile-phone": {
+        "character": "\uf3cd",
+        "searchterms": [
+            "apple",
+            "call",
+            "cell phone",
+            "cellphone",
+            "device",
+            "iphone",
+            "number",
+            "screen",
+            "telephone",
+            "mobile-alt",
+            "mobile-phone"
+        ]
+    },
+    "modx": {
+        "character": "\uf285",
+        "searchterms": [
+            "modx"
+        ]
+    },
+    "monero": {
+        "character": "\uf3d0",
+        "searchterms": [
+            "monero"
+        ]
+    },
+    "money": {
+        "character": "\uf3d1",
+        "searchterms": [
+            "buy",
+            "cash",
+            "checkout",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-bill-alt"
+        ]
+    },
+    "money-bill": {
+        "character": "\uf0d6",
+        "searchterms": [
+            "buy",
+            "cash",
+            "checkout",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-bill"
+        ]
+    },
+    "money-bill-alt": {
+        "character": "\uf3d1",
+        "searchterms": [
+            "buy",
+            "cash",
+            "checkout",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-bill-alt"
+        ]
+    },
+    "money-bill-wave": {
+        "character": "\uf53a",
+        "searchterms": [
+            "buy",
+            "cash",
+            "checkout",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-bill-wave"
+        ]
+    },
+    "money-bill-wave-alt": {
+        "character": "\uf53b",
+        "searchterms": [
+            "buy",
+            "cash",
+            "checkout",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-bill-wave-alt"
+        ]
+    },
+    "money-check": {
+        "character": "\uf53c",
+        "searchterms": [
+            "bank check",
+            "buy",
+            "checkout",
+            "cheque",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-check"
+        ]
+    },
+    "money-check-alt": {
+        "character": "\uf53d",
+        "searchterms": [
+            "bank check",
+            "buy",
+            "checkout",
+            "cheque",
+            "money",
+            "payment",
+            "price",
+            "purchase",
+            "money-check-alt"
+        ]
+    },
+    "monument": {
+        "character": "\uf5a6",
+        "searchterms": [
+            "building",
+            "historic",
+            "landmark",
+            "memorable",
+            "monument"
+        ]
+    },
+    "moon": {
+        "character": "\uf186",
+        "searchterms": [
+            "contrast",
+            "crescent",
+            "dark",
+            "lunar",
+            "night",
+            "moon",
+            "moon-o"
+        ]
+    },
+    "moon-o": {
+        "character": "\uf186",
+        "searchterms": [
+            "contrast",
+            "crescent",
+            "dark",
+            "lunar",
+            "night",
+            "moon",
+            "moon-o"
+        ]
+    },
+    "mortar-board": {
+        "character": "\uf19d",
+        "searchterms": [
+            "ceremony",
+            "college",
+            "graduate",
+            "learning",
+            "school",
+            "student",
+            "graduation-cap",
+            "mortar-board"
+        ]
+    },
+    "mortar-pestle": {
+        "character": "\uf5a7",
+        "searchterms": [
+            "crush",
+            "culinary",
+            "grind",
+            "medical",
+            "mix",
+            "pharmacy",
+            "prescription",
+            "spices",
+            "mortar-pestle"
+        ]
+    },
+    "mosque": {
+        "character": "\uf678",
+        "searchterms": [
+            "building",
+            "islam",
+            "landmark",
+            "muslim",
+            "mosque"
+        ]
+    },
+    "motorcycle": {
+        "character": "\uf21c",
+        "searchterms": [
+            "bike",
+            "machine",
+            "transportation",
+            "vehicle",
+            "motorcycle"
+        ]
+    },
+    "mountain": {
+        "character": "\uf6fc",
+        "searchterms": [
+            "glacier",
+            "hiking",
+            "hill",
+            "landscape",
+            "travel",
+            "view",
+            "mountain"
+        ]
+    },
+    "mouse": {
+        "character": "\uf8cc",
+        "searchterms": [
+            "click",
+            "computer",
+            "cursor",
+            "input",
+            "peripheral",
+            "mouse"
+        ]
+    },
+    "mouse-pointer": {
+        "character": "\uf245",
+        "searchterms": [
+            "arrow",
+            "cursor",
+            "select",
+            "mouse-pointer"
+        ]
+    },
+    "mug-hot": {
+        "character": "\uf7b6",
+        "searchterms": [
+            "caliente",
+            "cocoa",
+            "coffee",
+            "cup",
+            "drink",
+            "holiday",
+            "hot chocolate",
+            "steam",
+            "tea",
+            "warmth",
+            "mug-hot"
+        ]
+    },
+    "music": {
+        "character": "\uf001",
+        "searchterms": [
+            "lyrics",
+            "melody",
+            "note",
+            "sing",
+            "sound",
+            "music"
+        ]
+    },
+    "napster": {
+        "character": "\uf3d2",
+        "searchterms": [
+            "napster"
+        ]
+    },
+    "navicon": {
+        "character": "\uf0c9",
+        "searchterms": [
+            "checklist",
+            "drag",
+            "hamburger",
+            "list",
+            "menu",
+            "nav",
+            "navigation",
+            "ol",
+            "reorder",
+            "settings",
+            "todo",
+            "ul",
+            "bars",
+            "navicon"
+        ]
+    },
+    "neos": {
+        "character": "\uf612",
+        "searchterms": [
+            "neos"
+        ]
+    },
+    "network-wired": {
+        "character": "\uf6ff",
+        "searchterms": [
+            "computer",
+            "connect",
+            "ethernet",
+            "internet",
+            "intranet",
+            "network-wired"
+        ]
+    },
+    "neuter": {
+        "character": "\uf22c",
+        "searchterms": [
+            "neuter"
+        ]
+    },
+    "newspaper": {
+        "character": "\uf1ea",
+        "searchterms": [
+            "article",
+            "editorial",
+            "headline",
+            "journal",
+            "journalism",
+            "news",
+            "press",
+            "newspaper",
+            "newspaper-o"
+        ]
+    },
+    "newspaper-o": {
+        "character": "\uf1ea",
+        "searchterms": [
+            "article",
+            "editorial",
+            "headline",
+            "journal",
+            "journalism",
+            "news",
+            "press",
+            "newspaper",
+            "newspaper-o"
+        ]
+    },
+    "nimblr": {
+        "character": "\uf5a8",
+        "searchterms": [
+            "nimblr"
+        ]
+    },
+    "node": {
+        "character": "\uf419",
+        "searchterms": [
+            "node"
+        ]
+    },
+    "node-js": {
+        "character": "\uf3d3",
+        "searchterms": [
+            "node-js"
+        ]
+    },
+    "not-equal": {
+        "character": "\uf53e",
+        "searchterms": [
+            "arithmetic",
+            "compare",
+            "math",
+            "not-equal"
+        ]
+    },
+    "notes-medical": {
+        "character": "\uf481",
+        "searchterms": [
+            "clipboard",
+            "doctor",
+            "ehr",
+            "health",
+            "history",
+            "records",
+            "notes-medical"
+        ]
+    },
+    "npm": {
+        "character": "\uf3d4",
+        "searchterms": [
+            "npm"
+        ]
+    },
+    "ns8": {
+        "character": "\uf3d5",
+        "searchterms": [
+            "ns8"
+        ]
+    },
+    "nutritionix": {
+        "character": "\uf3d6",
+        "searchterms": [
+            "nutritionix"
+        ]
+    },
+    "object-group": {
+        "character": "\uf247",
+        "searchterms": [
+            "combine",
+            "copy",
+            "design",
+            "merge",
+            "select",
+            "object-group"
+        ]
+    },
+    "object-ungroup": {
+        "character": "\uf248",
+        "searchterms": [
+            "copy",
+            "design",
+            "merge",
+            "select",
+            "separate",
+            "object-ungroup"
+        ]
+    },
+    "odnoklassniki": {
+        "character": "\uf263",
+        "searchterms": [
+            "odnoklassniki"
+        ]
+    },
+    "odnoklassniki-square": {
+        "character": "\uf264",
+        "searchterms": [
+            "odnoklassniki-square"
+        ]
+    },
+    "oil-can": {
+        "character": "\uf613",
+        "searchterms": [
+            "auto",
+            "crude",
+            "gasoline",
+            "grease",
+            "lubricate",
+            "petroleum",
+            "oil-can"
+        ]
+    },
+    "old-republic": {
+        "character": "\uf510",
+        "searchterms": [
+            "politics",
+            "star wars",
+            "old-republic"
+        ]
+    },
+    "om": {
+        "character": "\uf679",
+        "searchterms": [
+            "buddhism",
+            "hinduism",
+            "jainism",
+            "mantra",
+            "om"
+        ]
+    },
+    "opencart": {
+        "character": "\uf23d",
+        "searchterms": [
+            "opencart"
+        ]
+    },
+    "openid": {
+        "character": "\uf19b",
+        "searchterms": [
+            "openid"
+        ]
+    },
+    "opera": {
+        "character": "\uf26a",
+        "searchterms": [
+            "opera"
+        ]
+    },
+    "optin-monster": {
+        "character": "\uf23c",
+        "searchterms": [
+            "optin-monster"
+        ]
+    },
+    "orcid": {
+        "character": "\uf8d2",
+        "searchterms": [
+            "orcid"
+        ]
+    },
+    "osi": {
+        "character": "\uf41a",
+        "searchterms": [
+            "osi"
+        ]
+    },
+    "otter": {
+        "character": "\uf700",
+        "searchterms": [
+            "animal",
+            "badger",
+            "fauna",
+            "fur",
+            "mammal",
+            "marten",
+            "otter"
+        ]
+    },
+    "outdent": {
+        "character": "\uf03b",
+        "searchterms": [
+            "align",
+            "justify",
+            "paragraph",
+            "tab",
+            "outdent",
+            "dedent"
+        ]
+    },
+    "page4": {
+        "character": "\uf3d7",
+        "searchterms": [
+            "page4"
+        ]
+    },
+    "pagelines": {
+        "character": "\uf18c",
+        "searchterms": [
+            "eco",
+            "flora",
+            "leaf",
+            "leaves",
+            "nature",
+            "plant",
+            "tree",
+            "pagelines"
+        ]
+    },
+    "pager": {
+        "character": "\uf815",
+        "searchterms": [
+            "beeper",
+            "cellphone",
+            "communication",
+            "pager"
+        ]
+    },
+    "paint-brush": {
+        "character": "\uf1fc",
+        "searchterms": [
+            "acrylic",
+            "art",
+            "brush",
+            "color",
+            "fill",
+            "paint",
+            "pigment",
+            "watercolor",
+            "paint-brush"
+        ]
+    },
+    "paint-roller": {
+        "character": "\uf5aa",
+        "searchterms": [
+            "acrylic",
+            "art",
+            "brush",
+            "color",
+            "fill",
+            "paint",
+            "pigment",
+            "watercolor",
+            "paint-roller"
+        ]
+    },
+    "palette": {
+        "character": "\uf53f",
+        "searchterms": [
+            "acrylic",
+            "art",
+            "brush",
+            "color",
+            "fill",
+            "paint",
+            "pigment",
+            "watercolor",
+            "palette"
+        ]
+    },
+    "palfed": {
+        "character": "\uf3d8",
+        "searchterms": [
+            "palfed"
+        ]
+    },
+    "pallet": {
+        "character": "\uf482",
+        "searchterms": [
+            "archive",
+            "box",
+            "inventory",
+            "shipping",
+            "warehouse",
+            "pallet"
+        ]
+    },
+    "paper-plane": {
+        "character": "\uf1d8",
+        "searchterms": [
+            "air",
+            "float",
+            "fold",
+            "mail",
+            "paper",
+            "send",
+            "paper-plane",
+            "paper-plane-o",
+            "send-o"
+        ]
+    },
+    "paper-plane-o": {
+        "character": "\uf1d8",
+        "searchterms": [
+            "air",
+            "float",
+            "fold",
+            "mail",
+            "paper",
+            "send",
+            "paper-plane",
+            "paper-plane-o",
+            "send-o"
+        ]
+    },
+    "paperclip": {
+        "character": "\uf0c6",
+        "searchterms": [
+            "attach",
+            "attachment",
+            "connect",
+            "link",
+            "paperclip"
+        ]
+    },
+    "parachute-box": {
+        "character": "\uf4cd",
+        "searchterms": [
+            "aid",
+            "assistance",
+            "rescue",
+            "supplies",
+            "parachute-box"
+        ]
+    },
+    "paragraph": {
+        "character": "\uf1dd",
+        "searchterms": [
+            "edit",
+            "format",
+            "text",
+            "writing",
+            "paragraph"
+        ]
+    },
+    "parking": {
+        "character": "\uf540",
+        "searchterms": [
+            "auto",
+            "car",
+            "garage",
+            "meter",
+            "parking"
+        ]
+    },
+    "passport": {
+        "character": "\uf5ab",
+        "searchterms": [
+            "document",
+            "id",
+            "identification",
+            "issued",
+            "travel",
+            "passport"
+        ]
+    },
+    "pastafarianism": {
+        "character": "\uf67b",
+        "searchterms": [
+            "agnosticism",
+            "atheism",
+            "flying spaghetti monster",
+            "fsm",
+            "pastafarianism"
+        ]
+    },
+    "paste": {
+        "character": "\uf0ea",
+        "searchterms": [
+            "clipboard",
+            "copy",
+            "document",
+            "paper",
+            "paste"
+        ]
+    },
+    "patreon": {
+        "character": "\uf3d9",
+        "searchterms": [
+            "patreon"
+        ]
+    },
+    "pause": {
+        "character": "\uf04c",
+        "searchterms": [
+            "hold",
+            "wait",
+            "pause"
+        ]
+    },
+    "pause-circle": {
+        "character": "\uf28b",
+        "searchterms": [
+            "hold",
+            "wait",
+            "pause-circle",
+            "pause-circle-o"
+        ]
+    },
+    "pause-circle-o": {
+        "character": "\uf28b",
+        "searchterms": [
+            "hold",
+            "wait",
+            "pause-circle",
+            "pause-circle-o"
+        ]
+    },
+    "paw": {
+        "character": "\uf1b0",
+        "searchterms": [
+            "animal",
+            "cat",
+            "dog",
+            "pet",
+            "print",
+            "paw"
+        ]
+    },
+    "paypal": {
+        "character": "\uf1ed",
+        "searchterms": [
+            "paypal"
+        ]
+    },
+    "peace": {
+        "character": "\uf67c",
+        "searchterms": [
+            "serenity",
+            "tranquility",
+            "truce",
+            "war",
+            "peace"
+        ]
+    },
+    "pen": {
+        "character": "\uf304",
+        "searchterms": [
+            "design",
+            "edit",
+            "update",
+            "write",
+            "pen"
+        ]
+    },
+    "pen-alt": {
+        "character": "\uf305",
+        "searchterms": [
+            "design",
+            "edit",
+            "update",
+            "write",
+            "pen-alt"
+        ]
+    },
+    "pen-fancy": {
+        "character": "\uf5ac",
+        "searchterms": [
+            "design",
+            "edit",
+            "fountain pen",
+            "update",
+            "write",
+            "pen-fancy"
+        ]
+    },
+    "pen-nib": {
+        "character": "\uf5ad",
+        "searchterms": [
+            "design",
+            "edit",
+            "fountain pen",
+            "update",
+            "write",
+            "pen-nib"
+        ]
+    },
+    "pen-square": {
+        "character": "\uf14b",
+        "searchterms": [
+            "edit",
+            "pencil-square",
+            "update",
+            "write",
+            "pen-square"
+        ]
+    },
+    "pencil": {
+        "character": "\uf303",
+        "searchterms": [
+            "design",
+            "edit",
+            "pencil",
+            "update",
+            "write",
+            "pencil-alt"
+        ]
+    },
+    "pencil-alt": {
+        "character": "\uf303",
+        "searchterms": [
+            "design",
+            "edit",
+            "pencil",
+            "update",
+            "write",
+            "pencil-alt"
+        ]
+    },
+    "pencil-ruler": {
+        "character": "\uf5ae",
+        "searchterms": [
+            "design",
+            "draft",
+            "draw",
+            "pencil",
+            "pencil-ruler"
+        ]
+    },
+    "pencil-square": {
+        "character": "\uf14b",
+        "searchterms": [
+            "edit",
+            "pencil-square",
+            "update",
+            "write",
+            "pen-square"
+        ]
+    },
+    "pencil-square-o": {
+        "character": "\uf044",
+        "searchterms": [
+            "edit",
+            "pen",
+            "pencil",
+            "update",
+            "write",
+            "pencil-square-o"
+        ]
+    },
+    "penny-arcade": {
+        "character": "\uf704",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "game",
+            "gaming",
+            "pax",
+            "tabletop",
+            "penny-arcade"
+        ]
+    },
+    "people-carry": {
+        "character": "\uf4ce",
+        "searchterms": [
+            "box",
+            "carry",
+            "fragile",
+            "help",
+            "movers",
+            "package",
+            "people-carry"
+        ]
+    },
+    "pepper-hot": {
+        "character": "\uf816",
+        "searchterms": [
+            "buffalo wings",
+            "capsicum",
+            "chili",
+            "chilli",
+            "habanero",
+            "jalapeno",
+            "mexican",
+            "spicy",
+            "tabasco",
+            "vegetable",
+            "pepper-hot"
+        ]
+    },
+    "percent": {
+        "character": "\uf295",
+        "searchterms": [
+            "discount",
+            "fraction",
+            "proportion",
+            "rate",
+            "ratio",
+            "percent"
+        ]
+    },
+    "percentage": {
+        "character": "\uf541",
+        "searchterms": [
+            "discount",
+            "fraction",
+            "proportion",
+            "rate",
+            "ratio",
+            "percentage"
+        ]
+    },
+    "periscope": {
+        "character": "\uf3da",
+        "searchterms": [
+            "periscope"
+        ]
+    },
+    "person-booth": {
+        "character": "\uf756",
+        "searchterms": [
+            "changing",
+            "changing room",
+            "election",
+            "human",
+            "person",
+            "vote",
+            "voting",
+            "person-booth"
+        ]
+    },
+    "phabricator": {
+        "character": "\uf3db",
+        "searchterms": [
+            "phabricator"
+        ]
+    },
+    "phoenix-framework": {
+        "character": "\uf3dc",
+        "searchterms": [
+            "phoenix-framework"
+        ]
+    },
+    "phoenix-squadron": {
+        "character": "\uf511",
+        "searchterms": [
+            "phoenix-squadron"
+        ]
+    },
+    "phone": {
+        "character": "\uf095",
+        "searchterms": [
+            "call",
+            "earphone",
+            "number",
+            "support",
+            "telephone",
+            "voice",
+            "phone"
+        ]
+    },
+    "phone-alt": {
+        "character": "\uf879",
+        "searchterms": [
+            "call",
+            "earphone",
+            "number",
+            "support",
+            "telephone",
+            "voice",
+            "phone-alt"
+        ]
+    },
+    "phone-slash": {
+        "character": "\uf3dd",
+        "searchterms": [
+            "call",
+            "cancel",
+            "earphone",
+            "mute",
+            "number",
+            "support",
+            "telephone",
+            "voice",
+            "phone-slash"
+        ]
+    },
+    "phone-square": {
+        "character": "\uf098",
+        "searchterms": [
+            "call",
+            "earphone",
+            "number",
+            "support",
+            "telephone",
+            "voice",
+            "phone-square"
+        ]
+    },
+    "phone-square-alt": {
+        "character": "\uf87b",
+        "searchterms": [
+            "call",
+            "earphone",
+            "number",
+            "support",
+            "telephone",
+            "voice",
+            "phone-square-alt"
+        ]
+    },
+    "phone-volume": {
+        "character": "\uf2a0",
+        "searchterms": [
+            "call",
+            "earphone",
+            "number",
+            "sound",
+            "support",
+            "telephone",
+            "voice",
+            "volume-control-phone",
+            "phone-volume"
+        ]
+    },
+    "photo": {
+        "character": "\uf03e",
+        "searchterms": [
+            "album",
+            "landscape",
+            "photo",
+            "picture",
+            "image",
+            "picture-o"
+        ]
+    },
+    "photo-video": {
+        "character": "\uf87c",
+        "searchterms": [
+            "av",
+            "film",
+            "image",
+            "library",
+            "media",
+            "photo-video"
+        ]
+    },
+    "php": {
+        "character": "\uf457",
+        "searchterms": [
+            "php"
+        ]
+    },
+    "picture-o": {
+        "character": "\uf03e",
+        "searchterms": [
+            "album",
+            "landscape",
+            "photo",
+            "picture",
+            "image",
+            "picture-o"
+        ]
+    },
+    "pie-chart": {
+        "character": "\uf200",
+        "searchterms": [
+            "analytics",
+            "chart",
+            "diagram",
+            "graph",
+            "pie",
+            "chart-pie",
+            "pie-chart"
+        ]
+    },
+    "pied-piper": {
+        "character": "\uf2ae",
+        "searchterms": [
+            "pied-piper"
+        ]
+    },
+    "pied-piper-alt": {
+        "character": "\uf1a8",
+        "searchterms": [
+            "pied-piper-alt"
+        ]
+    },
+    "pied-piper-hat": {
+        "character": "\uf4e5",
+        "searchterms": [
+            "clothing",
+            "pied-piper-hat"
+        ]
+    },
+    "pied-piper-pp": {
+        "character": "\uf1a7",
+        "searchterms": [
+            "pied-piper-pp"
+        ]
+    },
+    "piggy-bank": {
+        "character": "\uf4d3",
+        "searchterms": [
+            "bank",
+            "save",
+            "savings",
+            "piggy-bank"
+        ]
+    },
+    "pills": {
+        "character": "\uf484",
+        "searchterms": [
+            "drugs",
+            "medicine",
+            "prescription",
+            "tablets",
+            "pills"
+        ]
+    },
+    "pinterest": {
+        "character": "\uf0d2",
+        "searchterms": [
+            "pinterest"
+        ]
+    },
+    "pinterest-p": {
+        "character": "\uf231",
+        "searchterms": [
+            "pinterest-p"
+        ]
+    },
+    "pinterest-square": {
+        "character": "\uf0d3",
+        "searchterms": [
+            "pinterest-square"
+        ]
+    },
+    "pizza-slice": {
+        "character": "\uf818",
+        "searchterms": [
+            "cheese",
+            "chicago",
+            "italian",
+            "mozzarella",
+            "new york",
+            "pepperoni",
+            "pie",
+            "slice",
+            "teenage mutant ninja turtles",
+            "tomato",
+            "pizza-slice"
+        ]
+    },
+    "place-of-worship": {
+        "character": "\uf67f",
+        "searchterms": [
+            "building",
+            "church",
+            "holy",
+            "mosque",
+            "synagogue",
+            "place-of-worship"
+        ]
+    },
+    "plane": {
+        "character": "\uf072",
+        "searchterms": [
+            "airplane",
+            "destination",
+            "fly",
+            "location",
+            "mode",
+            "travel",
+            "trip",
+            "plane"
+        ]
+    },
+    "plane-arrival": {
+        "character": "\uf5af",
+        "searchterms": [
+            "airplane",
+            "arriving",
+            "destination",
+            "fly",
+            "land",
+            "landing",
+            "location",
+            "mode",
+            "travel",
+            "trip",
+            "plane-arrival"
+        ]
+    },
+    "plane-departure": {
+        "character": "\uf5b0",
+        "searchterms": [
+            "airplane",
+            "departing",
+            "destination",
+            "fly",
+            "location",
+            "mode",
+            "take off",
+            "taking off",
+            "travel",
+            "trip",
+            "plane-departure"
+        ]
+    },
+    "play": {
+        "character": "\uf04b",
+        "searchterms": [
+            "audio",
+            "music",
+            "playing",
+            "sound",
+            "start",
+            "video",
+            "play"
+        ]
+    },
+    "play-circle": {
+        "character": "\uf144",
+        "searchterms": [
+            "audio",
+            "music",
+            "playing",
+            "sound",
+            "start",
+            "video",
+            "play-circle",
+            "play-circle-o"
+        ]
+    },
+    "play-circle-o": {
+        "character": "\uf144",
+        "searchterms": [
+            "audio",
+            "music",
+            "playing",
+            "sound",
+            "start",
+            "video",
+            "play-circle",
+            "play-circle-o"
+        ]
+    },
+    "playstation": {
+        "character": "\uf3df",
+        "searchterms": [
+            "playstation"
+        ]
+    },
+    "plug": {
+        "character": "\uf1e6",
+        "searchterms": [
+            "connect",
+            "electric",
+            "online",
+            "power",
+            "plug"
+        ]
+    },
+    "plus": {
+        "character": "\uf067",
+        "searchterms": [
+            "add",
+            "create",
+            "expand",
+            "new",
+            "positive",
+            "shape",
+            "plus"
+        ]
+    },
+    "plus-circle": {
+        "character": "\uf055",
+        "searchterms": [
+            "add",
+            "create",
+            "expand",
+            "new",
+            "positive",
+            "shape",
+            "plus-circle"
+        ]
+    },
+    "plus-square": {
+        "character": "\uf0fe",
+        "searchterms": [
+            "add",
+            "create",
+            "expand",
+            "new",
+            "positive",
+            "shape",
+            "plus-square",
+            "plus-square-o"
+        ]
+    },
+    "plus-square-o": {
+        "character": "\uf0fe",
+        "searchterms": [
+            "add",
+            "create",
+            "expand",
+            "new",
+            "positive",
+            "shape",
+            "plus-square",
+            "plus-square-o"
+        ]
+    },
+    "podcast": {
+        "character": "\uf2ce",
+        "searchterms": [
+            "audio",
+            "broadcast",
+            "music",
+            "sound",
+            "podcast"
+        ]
+    },
+    "poll": {
+        "character": "\uf681",
+        "searchterms": [
+            "results",
+            "survey",
+            "trend",
+            "vote",
+            "voting",
+            "poll"
+        ]
+    },
+    "poll-h": {
+        "character": "\uf682",
+        "searchterms": [
+            "results",
+            "survey",
+            "trend",
+            "vote",
+            "voting",
+            "poll-h"
+        ]
+    },
+    "poo": {
+        "character": "\uf2fe",
+        "searchterms": [
+            "crap",
+            "poop",
+            "shit",
+            "smile",
+            "turd",
+            "poo"
+        ]
+    },
+    "poo-storm": {
+        "character": "\uf75a",
+        "searchterms": [
+            "bolt",
+            "cloud",
+            "euphemism",
+            "lightning",
+            "mess",
+            "poop",
+            "shit",
+            "turd",
+            "poo-storm"
+        ]
+    },
+    "poop": {
+        "character": "\uf619",
+        "searchterms": [
+            "crap",
+            "poop",
+            "shit",
+            "smile",
+            "turd"
+        ]
+    },
+    "portrait": {
+        "character": "\uf3e0",
+        "searchterms": [
+            "id",
+            "image",
+            "photo",
+            "picture",
+            "selfie",
+            "portrait"
+        ]
+    },
+    "pound-sign": {
+        "character": "\uf154",
+        "searchterms": [
+            "currency",
+            "gbp",
+            "money",
+            "pound-sign"
+        ]
+    },
+    "power-off": {
+        "character": "\uf011",
+        "searchterms": [
+            "cancel",
+            "computer",
+            "on",
+            "reboot",
+            "restart",
+            "power-off"
+        ]
+    },
+    "pray": {
+        "character": "\uf683",
+        "searchterms": [
+            "kneel",
+            "preach",
+            "religion",
+            "worship",
+            "pray"
+        ]
+    },
+    "praying-hands": {
+        "character": "\uf684",
+        "searchterms": [
+            "kneel",
+            "preach",
+            "religion",
+            "worship",
+            "praying-hands"
+        ]
+    },
+    "prescription": {
+        "character": "\uf5b1",
+        "searchterms": [
+            "drugs",
+            "medical",
+            "medicine",
+            "pharmacy",
+            "rx",
+            "prescription"
+        ]
+    },
+    "prescription-bottle": {
+        "character": "\uf485",
+        "searchterms": [
+            "drugs",
+            "medical",
+            "medicine",
+            "pharmacy",
+            "rx",
+            "prescription-bottle"
+        ]
+    },
+    "prescription-bottle-alt": {
+        "character": "\uf486",
+        "searchterms": [
+            "drugs",
+            "medical",
+            "medicine",
+            "pharmacy",
+            "rx",
+            "prescription-bottle-alt"
+        ]
+    },
+    "print": {
+        "character": "\uf02f",
+        "searchterms": [
+            "business",
+            "copy",
+            "document",
+            "office",
+            "paper",
+            "print"
+        ]
+    },
+    "procedures": {
+        "character": "\uf487",
+        "searchterms": [
+            "EKG",
+            "bed",
+            "electrocardiogram",
+            "health",
+            "hospital",
+            "life",
+            "patient",
+            "vital",
+            "procedures"
+        ]
+    },
+    "product-hunt": {
+        "character": "\uf288",
+        "searchterms": [
+            "product-hunt"
+        ]
+    },
+    "project-diagram": {
+        "character": "\uf542",
+        "searchterms": [
+            "chart",
+            "graph",
+            "network",
+            "pert",
+            "project-diagram"
+        ]
+    },
+    "pushed": {
+        "character": "\uf3e1",
+        "searchterms": [
+            "pushed"
+        ]
+    },
+    "puzzle-piece": {
+        "character": "\uf12e",
+        "searchterms": [
+            "add-on",
+            "addon",
+            "game",
+            "section",
+            "puzzle-piece"
+        ]
+    },
+    "python": {
+        "character": "\uf3e2",
+        "searchterms": [
+            "python"
+        ]
+    },
+    "qq": {
+        "character": "\uf1d6",
+        "searchterms": [
+            "qq"
+        ]
+    },
+    "qrcode": {
+        "character": "\uf029",
+        "searchterms": [
+            "barcode",
+            "info",
+            "information",
+            "scan",
+            "qrcode"
+        ]
+    },
+    "question": {
+        "character": "\uf128",
+        "searchterms": [
+            "help",
+            "information",
+            "support",
+            "unknown",
+            "question"
+        ]
+    },
+    "question-circle": {
+        "character": "\uf059",
+        "searchterms": [
+            "help",
+            "information",
+            "support",
+            "unknown",
+            "question-circle",
+            "question-circle-o"
+        ]
+    },
+    "question-circle-o": {
+        "character": "\uf059",
+        "searchterms": [
+            "help",
+            "information",
+            "support",
+            "unknown",
+            "question-circle",
+            "question-circle-o"
+        ]
+    },
+    "quidditch": {
+        "character": "\uf458",
+        "searchterms": [
+            "ball",
+            "bludger",
+            "broom",
+            "golden snitch",
+            "harry potter",
+            "hogwarts",
+            "quaffle",
+            "sport",
+            "wizard",
+            "quidditch"
+        ]
+    },
+    "quinscape": {
+        "character": "\uf459",
+        "searchterms": [
+            "quinscape"
+        ]
+    },
+    "quora": {
+        "character": "\uf2c4",
+        "searchterms": [
+            "quora"
+        ]
+    },
+    "quote-left": {
+        "character": "\uf10d",
+        "searchterms": [
+            "mention",
+            "note",
+            "phrase",
+            "text",
+            "type",
+            "quote-left"
+        ]
+    },
+    "quote-right": {
+        "character": "\uf10e",
+        "searchterms": [
+            "mention",
+            "note",
+            "phrase",
+            "text",
+            "type",
+            "quote-right"
+        ]
+    },
+    "quran": {
+        "character": "\uf687",
+        "searchterms": [
+            "book",
+            "islam",
+            "muslim",
+            "religion",
+            "quran"
+        ]
+    },
+    "r-project": {
+        "character": "\uf4f7",
+        "searchterms": [
+            "r-project"
+        ]
+    },
+    "ra": {
+        "character": "\uf1d0",
+        "searchterms": [
+            "rebel",
+            "ra",
+            "resistance"
+        ]
+    },
+    "radiation": {
+        "character": "\uf7b9",
+        "searchterms": [
+            "danger",
+            "dangerous",
+            "deadly",
+            "hazard",
+            "nuclear",
+            "radioactive",
+            "warning",
+            "radiation"
+        ]
+    },
+    "radiation-alt": {
+        "character": "\uf7ba",
+        "searchterms": [
+            "danger",
+            "dangerous",
+            "deadly",
+            "hazard",
+            "nuclear",
+            "radioactive",
+            "warning",
+            "radiation-alt"
+        ]
+    },
+    "rainbow": {
+        "character": "\uf75b",
+        "searchterms": [
+            "gold",
+            "leprechaun",
+            "prism",
+            "rain",
+            "sky",
+            "rainbow"
+        ]
+    },
+    "random": {
+        "character": "\uf074",
+        "searchterms": [
+            "arrows",
+            "shuffle",
+            "sort",
+            "swap",
+            "switch",
+            "transfer",
+            "random"
+        ]
+    },
+    "raspberry-pi": {
+        "character": "\uf7bb",
+        "searchterms": [
+            "raspberry-pi"
+        ]
+    },
+    "ravelry": {
+        "character": "\uf2d9",
+        "searchterms": [
+            "ravelry"
+        ]
+    },
+    "react": {
+        "character": "\uf41b",
+        "searchterms": [
+            "react"
+        ]
+    },
+    "reacteurope": {
+        "character": "\uf75d",
+        "searchterms": [
+            "reacteurope"
+        ]
+    },
+    "readme": {
+        "character": "\uf4d5",
+        "searchterms": [
+            "readme"
+        ]
+    },
+    "rebel": {
+        "character": "\uf1d0",
+        "searchterms": [
+            "rebel",
+            "ra",
+            "resistance"
+        ]
+    },
+    "receipt": {
+        "character": "\uf543",
+        "searchterms": [
+            "check",
+            "invoice",
+            "money",
+            "pay",
+            "table",
+            "receipt"
+        ]
+    },
+    "record-vinyl": {
+        "character": "\uf8d9",
+        "searchterms": [
+            "LP",
+            "album",
+            "analog",
+            "music",
+            "phonograph",
+            "sound",
+            "record-vinyl"
+        ]
+    },
+    "recycle": {
+        "character": "\uf1b8",
+        "searchterms": [
+            "Waste",
+            "compost",
+            "garbage",
+            "reuse",
+            "trash",
+            "recycle"
+        ]
+    },
+    "red-river": {
+        "character": "\uf3e3",
+        "searchterms": [
+            "red-river"
+        ]
+    },
+    "reddit": {
+        "character": "\uf1a1",
+        "searchterms": [
+            "reddit"
+        ]
+    },
+    "reddit-alien": {
+        "character": "\uf281",
+        "searchterms": [
+            "reddit-alien"
+        ]
+    },
+    "reddit-square": {
+        "character": "\uf1a2",
+        "searchterms": [
+            "reddit-square"
+        ]
+    },
+    "redhat": {
+        "character": "\uf7bc",
+        "searchterms": [
+            "linux",
+            "operating system",
+            "os",
+            "redhat"
+        ]
+    },
+    "redo": {
+        "character": "\uf01e",
+        "searchterms": [
+            "forward",
+            "refresh",
+            "reload",
+            "repeat",
+            "redo",
+            "rotate-right"
+        ]
+    },
+    "redo-alt": {
+        "character": "\uf2f9",
+        "searchterms": [
+            "forward",
+            "refresh",
+            "reload",
+            "repeat",
+            "redo-alt"
+        ]
+    },
+    "refresh": {
+        "character": "\uf021",
+        "searchterms": [
+            "exchange",
+            "refresh",
+            "reload",
+            "rotate",
+            "swap",
+            "sync"
+        ]
+    },
+    "registered": {
+        "character": "\uf25d",
+        "searchterms": [
+            "copyright",
+            "mark",
+            "trademark",
+            "registered"
+        ]
+    },
+    "remove": {
+        "character": "\uf00d",
+        "searchterms": [
+            "close",
+            "cross",
+            "error",
+            "exit",
+            "incorrect",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "wrong",
+            "x",
+            "times",
+            "remove"
+        ]
+    },
+    "remove-format": {
+        "character": "\uf87d",
+        "searchterms": [
+            "cancel",
+            "font",
+            "format",
+            "remove",
+            "style",
+            "text",
+            "remove-format"
+        ]
+    },
+    "renren": {
+        "character": "\uf18b",
+        "searchterms": [
+            "renren"
+        ]
+    },
+    "reorder": {
+        "character": "\uf0c9",
+        "searchterms": [
+            "checklist",
+            "drag",
+            "hamburger",
+            "list",
+            "menu",
+            "nav",
+            "navigation",
+            "ol",
+            "reorder",
+            "settings",
+            "todo",
+            "ul",
+            "bars",
+            "navicon"
+        ]
+    },
+    "repeat": {
+        "character": "\uf01e",
+        "searchterms": [
+            "forward",
+            "refresh",
+            "reload",
+            "repeat",
+            "redo",
+            "rotate-right"
+        ]
+    },
+    "reply": {
+        "character": "\uf3e5",
+        "searchterms": [
+            "mail",
+            "message",
+            "respond",
+            "reply",
+            "mail-reply"
+        ]
+    },
+    "reply-all": {
+        "character": "\uf122",
+        "searchterms": [
+            "mail",
+            "message",
+            "respond",
+            "reply-all",
+            "mail-reply-all"
+        ]
+    },
+    "replyd": {
+        "character": "\uf3e6",
+        "searchterms": [
+            "replyd"
+        ]
+    },
+    "republican": {
+        "character": "\uf75e",
+        "searchterms": [
+            "american",
+            "conservative",
+            "election",
+            "elephant",
+            "politics",
+            "republican party",
+            "right",
+            "right-wing",
+            "usa",
+            "republican"
+        ]
+    },
+    "researchgate": {
+        "character": "\uf4f8",
+        "searchterms": [
+            "researchgate"
+        ]
+    },
+    "resistance": {
+        "character": "\uf1d0",
+        "searchterms": [
+            "rebel",
+            "ra",
+            "resistance"
+        ]
+    },
+    "resolving": {
+        "character": "\uf3e7",
+        "searchterms": [
+            "resolving"
+        ]
+    },
+    "restroom": {
+        "character": "\uf7bd",
+        "searchterms": [
+            "bathroom",
+            "john",
+            "loo",
+            "potty",
+            "washroom",
+            "waste",
+            "wc",
+            "restroom"
+        ]
+    },
+    "retweet": {
+        "character": "\uf079",
+        "searchterms": [
+            "refresh",
+            "reload",
+            "share",
+            "swap",
+            "retweet"
+        ]
+    },
+    "rev": {
+        "character": "\uf5b2",
+        "searchterms": [
+            "rev"
+        ]
+    },
+    "ribbon": {
+        "character": "\uf4d6",
+        "searchterms": [
+            "badge",
+            "cause",
+            "lapel",
+            "pin",
+            "ribbon"
+        ]
+    },
+    "ring": {
+        "character": "\uf70b",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "Gollum",
+            "band",
+            "binding",
+            "d&d",
+            "dnd",
+            "engagement",
+            "fantasy",
+            "gold",
+            "jewelry",
+            "marriage",
+            "precious",
+            "ring"
+        ]
+    },
+    "rmb": {
+        "character": "\uf157",
+        "searchterms": [
+            "currency",
+            "jpy",
+            "money",
+            "yen-sign",
+            "cny",
+            "rmb",
+            "yen"
+        ]
+    },
+    "road": {
+        "character": "\uf018",
+        "searchterms": [
+            "highway",
+            "map",
+            "pavement",
+            "route",
+            "street",
+            "travel",
+            "road"
+        ]
+    },
+    "robot": {
+        "character": "\uf544",
+        "searchterms": [
+            "android",
+            "automate",
+            "computer",
+            "cyborg",
+            "robot"
+        ]
+    },
+    "rocket": {
+        "character": "\uf135",
+        "searchterms": [
+            "aircraft",
+            "app",
+            "jet",
+            "launch",
+            "nasa",
+            "space",
+            "rocket"
+        ]
+    },
+    "rocketchat": {
+        "character": "\uf3e8",
+        "searchterms": [
+            "rocketchat"
+        ]
+    },
+    "rockrms": {
+        "character": "\uf3e9",
+        "searchterms": [
+            "rockrms"
+        ]
+    },
+    "rotate-left": {
+        "character": "\uf0e2",
+        "searchterms": [
+            "back",
+            "control z",
+            "exchange",
+            "oops",
+            "return",
+            "rotate",
+            "swap",
+            "undo",
+            "rotate-left"
+        ]
+    },
+    "rotate-right": {
+        "character": "\uf01e",
+        "searchterms": [
+            "forward",
+            "refresh",
+            "reload",
+            "repeat",
+            "redo",
+            "rotate-right"
+        ]
+    },
+    "rouble": {
+        "character": "\uf158",
+        "searchterms": [
+            "currency",
+            "money",
+            "rub",
+            "ruble-sign",
+            "ruble",
+            "rouble"
+        ]
+    },
+    "route": {
+        "character": "\uf4d7",
+        "searchterms": [
+            "directions",
+            "navigation",
+            "travel",
+            "route"
+        ]
+    },
+    "rss": {
+        "character": "\uf09e",
+        "searchterms": [
+            "blog",
+            "feed",
+            "journal",
+            "news",
+            "writing",
+            "rss"
+        ]
+    },
+    "rss-square": {
+        "character": "\uf143",
+        "searchterms": [
+            "blog",
+            "feed",
+            "journal",
+            "news",
+            "writing",
+            "rss-square"
+        ]
+    },
+    "rub": {
+        "character": "\uf158",
+        "searchterms": [
+            "currency",
+            "money",
+            "rub",
+            "ruble-sign",
+            "ruble",
+            "rouble"
+        ]
+    },
+    "ruble": {
+        "character": "\uf158",
+        "searchterms": [
+            "currency",
+            "money",
+            "rub",
+            "ruble-sign",
+            "ruble",
+            "rouble"
+        ]
+    },
+    "ruble-sign": {
+        "character": "\uf158",
+        "searchterms": [
+            "currency",
+            "money",
+            "rub",
+            "ruble-sign",
+            "ruble",
+            "rouble"
+        ]
+    },
+    "ruler": {
+        "character": "\uf545",
+        "searchterms": [
+            "design",
+            "draft",
+            "length",
+            "measure",
+            "planning",
+            "ruler"
+        ]
+    },
+    "ruler-combined": {
+        "character": "\uf546",
+        "searchterms": [
+            "design",
+            "draft",
+            "length",
+            "measure",
+            "planning",
+            "ruler-combined"
+        ]
+    },
+    "ruler-horizontal": {
+        "character": "\uf547",
+        "searchterms": [
+            "design",
+            "draft",
+            "length",
+            "measure",
+            "planning",
+            "ruler-horizontal"
+        ]
+    },
+    "ruler-vertical": {
+        "character": "\uf548",
+        "searchterms": [
+            "design",
+            "draft",
+            "length",
+            "measure",
+            "planning",
+            "ruler-vertical"
+        ]
+    },
+    "running": {
+        "character": "\uf70c",
+        "searchterms": [
+            "exercise",
+            "health",
+            "jog",
+            "person",
+            "run",
+            "sport",
+            "sprint",
+            "running"
+        ]
+    },
+    "rupee": {
+        "character": "\uf156",
+        "searchterms": [
+            "currency",
+            "indian",
+            "inr",
+            "money",
+            "rupee-sign",
+            "rupee"
+        ]
+    },
+    "rupee-sign": {
+        "character": "\uf156",
+        "searchterms": [
+            "currency",
+            "indian",
+            "inr",
+            "money",
+            "rupee-sign",
+            "rupee"
+        ]
+    },
+    "s15": {
+        "character": "\uf2cd",
+        "searchterms": [
+            "clean",
+            "shower",
+            "tub",
+            "wash",
+            "bath",
+            "bathtub",
+            "s15"
+        ]
+    },
+    "sad-cry": {
+        "character": "\uf5b3",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "tear",
+            "tears",
+            "sad-cry"
+        ]
+    },
+    "sad-tear": {
+        "character": "\uf5b4",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "tear",
+            "tears",
+            "sad-tear"
+        ]
+    },
+    "safari": {
+        "character": "\uf267",
+        "searchterms": [
+            "browser",
+            "safari"
+        ]
+    },
+    "salesforce": {
+        "character": "\uf83b",
+        "searchterms": [
+            "salesforce"
+        ]
+    },
+    "sass": {
+        "character": "\uf41e",
+        "searchterms": [
+            "sass"
+        ]
+    },
+    "satellite": {
+        "character": "\uf7bf",
+        "searchterms": [
+            "communications",
+            "hardware",
+            "orbit",
+            "space",
+            "satellite"
+        ]
+    },
+    "satellite-dish": {
+        "character": "\uf7c0",
+        "searchterms": [
+            "SETI",
+            "communications",
+            "hardware",
+            "receiver",
+            "saucer",
+            "signal",
+            "space",
+            "satellite-dish"
+        ]
+    },
+    "save": {
+        "character": "\uf0c7",
+        "searchterms": [
+            "disk",
+            "download",
+            "floppy",
+            "floppy-o",
+            "save"
+        ]
+    },
+    "schlix": {
+        "character": "\uf3ea",
+        "searchterms": [
+            "schlix"
+        ]
+    },
+    "school": {
+        "character": "\uf549",
+        "searchterms": [
+            "building",
+            "education",
+            "learn",
+            "student",
+            "teacher",
+            "school"
+        ]
+    },
+    "scissors": {
+        "character": "\uf0c4",
+        "searchterms": [
+            "clip",
+            "scissors",
+            "snip",
+            "cut"
+        ]
+    },
+    "screwdriver": {
+        "character": "\uf54a",
+        "searchterms": [
+            "admin",
+            "fix",
+            "mechanic",
+            "repair",
+            "settings",
+            "tool",
+            "screwdriver"
+        ]
+    },
+    "scribd": {
+        "character": "\uf28a",
+        "searchterms": [
+            "scribd"
+        ]
+    },
+    "scroll": {
+        "character": "\uf70e",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "announcement",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "paper",
+            "script",
+            "scroll"
+        ]
+    },
+    "sd-card": {
+        "character": "\uf7c2",
+        "searchterms": [
+            "image",
+            "memory",
+            "photo",
+            "save",
+            "sd-card"
+        ]
+    },
+    "search": {
+        "character": "\uf002",
+        "searchterms": [
+            "bigger",
+            "enlarge",
+            "find",
+            "magnify",
+            "preview",
+            "zoom",
+            "search"
+        ]
+    },
+    "search-dollar": {
+        "character": "\uf688",
+        "searchterms": [
+            "bigger",
+            "enlarge",
+            "find",
+            "magnify",
+            "money",
+            "preview",
+            "zoom",
+            "search-dollar"
+        ]
+    },
+    "search-location": {
+        "character": "\uf689",
+        "searchterms": [
+            "bigger",
+            "enlarge",
+            "find",
+            "magnify",
+            "preview",
+            "zoom",
+            "search-location"
+        ]
+    },
+    "search-minus": {
+        "character": "\uf010",
+        "searchterms": [
+            "minify",
+            "negative",
+            "smaller",
+            "zoom",
+            "zoom out",
+            "search-minus"
+        ]
+    },
+    "search-plus": {
+        "character": "\uf00e",
+        "searchterms": [
+            "bigger",
+            "enlarge",
+            "magnify",
+            "positive",
+            "zoom",
+            "zoom in",
+            "search-plus"
+        ]
+    },
+    "searchengin": {
+        "character": "\uf3eb",
+        "searchterms": [
+            "searchengin"
+        ]
+    },
+    "seedling": {
+        "character": "\uf4d8",
+        "searchterms": [
+            "flora",
+            "grow",
+            "plant",
+            "vegan",
+            "seedling"
+        ]
+    },
+    "sellcast": {
+        "character": "\uf2da",
+        "searchterms": [
+            "eercast",
+            "sellcast"
+        ]
+    },
+    "sellsy": {
+        "character": "\uf213",
+        "searchterms": [
+            "sellsy"
+        ]
+    },
+    "send": {
+        "character": "\uf1d8",
+        "searchterms": [
+            "air",
+            "float",
+            "fold",
+            "mail",
+            "paper",
+            "send",
+            "paper-plane",
+            "paper-plane-o",
+            "send-o"
+        ]
+    },
+    "send-o": {
+        "character": "\uf1d8",
+        "searchterms": [
+            "air",
+            "float",
+            "fold",
+            "mail",
+            "paper",
+            "send",
+            "paper-plane",
+            "paper-plane-o",
+            "send-o"
+        ]
+    },
+    "server": {
+        "character": "\uf233",
+        "searchterms": [
+            "computer",
+            "cpu",
+            "database",
+            "hardware",
+            "network",
+            "server"
+        ]
+    },
+    "servicestack": {
+        "character": "\uf3ec",
+        "searchterms": [
+            "servicestack"
+        ]
+    },
+    "shapes": {
+        "character": "\uf61f",
+        "searchterms": [
+            "blocks",
+            "build",
+            "circle",
+            "square",
+            "triangle",
+            "shapes"
+        ]
+    },
+    "share": {
+        "character": "\uf064",
+        "searchterms": [
+            "forward",
+            "save",
+            "send",
+            "social",
+            "share",
+            "mail-forward"
+        ]
+    },
+    "share-alt": {
+        "character": "\uf1e0",
+        "searchterms": [
+            "forward",
+            "save",
+            "send",
+            "social",
+            "share-alt"
+        ]
+    },
+    "share-alt-square": {
+        "character": "\uf1e1",
+        "searchterms": [
+            "forward",
+            "save",
+            "send",
+            "social",
+            "share-alt-square"
+        ]
+    },
+    "share-square": {
+        "character": "\uf14d",
+        "searchterms": [
+            "forward",
+            "save",
+            "send",
+            "social",
+            "share-square",
+            "share-square-o"
+        ]
+    },
+    "share-square-o": {
+        "character": "\uf14d",
+        "searchterms": [
+            "forward",
+            "save",
+            "send",
+            "social",
+            "share-square",
+            "share-square-o"
+        ]
+    },
+    "shekel": {
+        "character": "\uf20b",
+        "searchterms": [
+            "currency",
+            "ils",
+            "money",
+            "shekel-sign",
+            "shekel",
+            "sheqel"
+        ]
+    },
+    "shekel-sign": {
+        "character": "\uf20b",
+        "searchterms": [
+            "currency",
+            "ils",
+            "money",
+            "shekel-sign",
+            "shekel",
+            "sheqel"
+        ]
+    },
+    "sheqel": {
+        "character": "\uf20b",
+        "searchterms": [
+            "currency",
+            "ils",
+            "money",
+            "shekel-sign",
+            "shekel",
+            "sheqel"
+        ]
+    },
+    "shield": {
+        "character": "\uf3ed",
+        "searchterms": [
+            "achievement",
+            "award",
+            "block",
+            "defend",
+            "security",
+            "winner",
+            "shield-alt",
+            "shield"
+        ]
+    },
+    "shield-alt": {
+        "character": "\uf3ed",
+        "searchterms": [
+            "achievement",
+            "award",
+            "block",
+            "defend",
+            "security",
+            "winner",
+            "shield-alt",
+            "shield"
+        ]
+    },
+    "ship": {
+        "character": "\uf21a",
+        "searchterms": [
+            "boat",
+            "sea",
+            "water",
+            "ship"
+        ]
+    },
+    "shipping-fast": {
+        "character": "\uf48b",
+        "searchterms": [
+            "express",
+            "fedex",
+            "mail",
+            "overnight",
+            "package",
+            "ups",
+            "shipping-fast"
+        ]
+    },
+    "shirtsinbulk": {
+        "character": "\uf214",
+        "searchterms": [
+            "shirtsinbulk"
+        ]
+    },
+    "shoe-prints": {
+        "character": "\uf54b",
+        "searchterms": [
+            "feet",
+            "footprints",
+            "steps",
+            "walk",
+            "shoe-prints"
+        ]
+    },
+    "shopping-bag": {
+        "character": "\uf290",
+        "searchterms": [
+            "buy",
+            "checkout",
+            "grocery",
+            "payment",
+            "purchase",
+            "shopping-bag"
+        ]
+    },
+    "shopping-basket": {
+        "character": "\uf291",
+        "searchterms": [
+            "buy",
+            "checkout",
+            "grocery",
+            "payment",
+            "purchase",
+            "shopping-basket"
+        ]
+    },
+    "shopping-cart": {
+        "character": "\uf07a",
+        "searchterms": [
+            "buy",
+            "checkout",
+            "grocery",
+            "payment",
+            "purchase",
+            "shopping-cart"
+        ]
+    },
+    "shopware": {
+        "character": "\uf5b5",
+        "searchterms": [
+            "shopware"
+        ]
+    },
+    "shower": {
+        "character": "\uf2cc",
+        "searchterms": [
+            "bath",
+            "clean",
+            "faucet",
+            "water",
+            "shower"
+        ]
+    },
+    "shuttle-van": {
+        "character": "\uf5b6",
+        "searchterms": [
+            "airport",
+            "machine",
+            "public-transportation",
+            "transportation",
+            "travel",
+            "vehicle",
+            "shuttle-van"
+        ]
+    },
+    "sign": {
+        "character": "\uf4d9",
+        "searchterms": [
+            "directions",
+            "real estate",
+            "signage",
+            "wayfinding",
+            "sign"
+        ]
+    },
+    "sign-in": {
+        "character": "\uf2f6",
+        "searchterms": [
+            "arrow",
+            "enter",
+            "join",
+            "log in",
+            "login",
+            "sign in",
+            "sign up",
+            "sign-in",
+            "signin",
+            "signup",
+            "sign-in-alt"
+        ]
+    },
+    "sign-in-alt": {
+        "character": "\uf2f6",
+        "searchterms": [
+            "arrow",
+            "enter",
+            "join",
+            "log in",
+            "login",
+            "sign in",
+            "sign up",
+            "sign-in",
+            "signin",
+            "signup",
+            "sign-in-alt"
+        ]
+    },
+    "sign-language": {
+        "character": "\uf2a7",
+        "searchterms": [
+            "Translate",
+            "asl",
+            "deaf",
+            "hands",
+            "sign-language",
+            "signing"
+        ]
+    },
+    "sign-out": {
+        "character": "\uf2f5",
+        "searchterms": [
+            "arrow",
+            "exit",
+            "leave",
+            "log out",
+            "logout",
+            "sign-out",
+            "sign-out-alt"
+        ]
+    },
+    "sign-out-alt": {
+        "character": "\uf2f5",
+        "searchterms": [
+            "arrow",
+            "exit",
+            "leave",
+            "log out",
+            "logout",
+            "sign-out",
+            "sign-out-alt"
+        ]
+    },
+    "signal": {
+        "character": "\uf012",
+        "searchterms": [
+            "bars",
+            "graph",
+            "online",
+            "reception",
+            "status",
+            "signal"
+        ]
+    },
+    "signature": {
+        "character": "\uf5b7",
+        "searchterms": [
+            "John Hancock",
+            "cursive",
+            "name",
+            "writing",
+            "signature"
+        ]
+    },
+    "signing": {
+        "character": "\uf2a7",
+        "searchterms": [
+            "Translate",
+            "asl",
+            "deaf",
+            "hands",
+            "sign-language",
+            "signing"
+        ]
+    },
+    "sim-card": {
+        "character": "\uf7c4",
+        "searchterms": [
+            "hard drive",
+            "hardware",
+            "portable",
+            "storage",
+            "technology",
+            "tiny",
+            "sim-card"
+        ]
+    },
+    "simplybuilt": {
+        "character": "\uf215",
+        "searchterms": [
+            "simplybuilt"
+        ]
+    },
+    "sistrix": {
+        "character": "\uf3ee",
+        "searchterms": [
+            "sistrix"
+        ]
+    },
+    "sitemap": {
+        "character": "\uf0e8",
+        "searchterms": [
+            "directory",
+            "hierarchy",
+            "ia",
+            "information architecture",
+            "organization",
+            "sitemap"
+        ]
+    },
+    "sith": {
+        "character": "\uf512",
+        "searchterms": [
+            "sith"
+        ]
+    },
+    "skating": {
+        "character": "\uf7c5",
+        "searchterms": [
+            "activity",
+            "figure skating",
+            "fitness",
+            "ice",
+            "person",
+            "winter",
+            "skating"
+        ]
+    },
+    "sketch": {
+        "character": "\uf7c6",
+        "searchterms": [
+            "app",
+            "design",
+            "interface",
+            "sketch"
+        ]
+    },
+    "skiing": {
+        "character": "\uf7c9",
+        "searchterms": [
+            "activity",
+            "downhill",
+            "fast",
+            "fitness",
+            "olympics",
+            "outdoors",
+            "person",
+            "seasonal",
+            "slalom",
+            "skiing"
+        ]
+    },
+    "skiing-nordic": {
+        "character": "\uf7ca",
+        "searchterms": [
+            "activity",
+            "cross country",
+            "fitness",
+            "outdoors",
+            "person",
+            "seasonal",
+            "skiing-nordic"
+        ]
+    },
+    "skull": {
+        "character": "\uf54c",
+        "searchterms": [
+            "bones",
+            "skeleton",
+            "x-ray",
+            "yorick",
+            "skull"
+        ]
+    },
+    "skull-crossbones": {
+        "character": "\uf714",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "alert",
+            "bones",
+            "d&d",
+            "danger",
+            "dead",
+            "deadly",
+            "death",
+            "dnd",
+            "fantasy",
+            "halloween",
+            "holiday",
+            "jolly-roger",
+            "pirate",
+            "poison",
+            "skeleton",
+            "warning",
+            "skull-crossbones"
+        ]
+    },
+    "skyatlas": {
+        "character": "\uf216",
+        "searchterms": [
+            "skyatlas"
+        ]
+    },
+    "skype": {
+        "character": "\uf17e",
+        "searchterms": [
+            "skype"
+        ]
+    },
+    "slack": {
+        "character": "\uf198",
+        "searchterms": [
+            "anchor",
+            "hash",
+            "hashtag",
+            "slack"
+        ]
+    },
+    "slack-hash": {
+        "character": "\uf3ef",
+        "searchterms": [
+            "anchor",
+            "hash",
+            "hashtag",
+            "slack-hash"
+        ]
+    },
+    "slash": {
+        "character": "\uf715",
+        "searchterms": [
+            "cancel",
+            "close",
+            "mute",
+            "off",
+            "stop",
+            "x",
+            "slash"
+        ]
+    },
+    "sleigh": {
+        "character": "\uf7cc",
+        "searchterms": [
+            "christmas",
+            "claus",
+            "fly",
+            "holiday",
+            "santa",
+            "sled",
+            "snow",
+            "xmas",
+            "sleigh"
+        ]
+    },
+    "sliders": {
+        "character": "\uf1de",
+        "searchterms": [
+            "adjust",
+            "settings",
+            "sliders",
+            "toggle",
+            "sliders-h"
+        ]
+    },
+    "sliders-h": {
+        "character": "\uf1de",
+        "searchterms": [
+            "adjust",
+            "settings",
+            "sliders",
+            "toggle",
+            "sliders-h"
+        ]
+    },
+    "slideshare": {
+        "character": "\uf1e7",
+        "searchterms": [
+            "slideshare"
+        ]
+    },
+    "smile": {
+        "character": "\uf118",
+        "searchterms": [
+            "approve",
+            "emoticon",
+            "face",
+            "happy",
+            "rating",
+            "satisfied",
+            "smile",
+            "smile-o"
+        ]
+    },
+    "smile-beam": {
+        "character": "\uf5b8",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "happy",
+            "positive",
+            "smile-beam"
+        ]
+    },
+    "smile-o": {
+        "character": "\uf118",
+        "searchterms": [
+            "approve",
+            "emoticon",
+            "face",
+            "happy",
+            "rating",
+            "satisfied",
+            "smile",
+            "smile-o"
+        ]
+    },
+    "smile-wink": {
+        "character": "\uf4da",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "happy",
+            "hint",
+            "joke",
+            "smile-wink"
+        ]
+    },
+    "smog": {
+        "character": "\uf75f",
+        "searchterms": [
+            "dragon",
+            "fog",
+            "haze",
+            "pollution",
+            "smoke",
+            "weather",
+            "smog"
+        ]
+    },
+    "smoking": {
+        "character": "\uf48d",
+        "searchterms": [
+            "cancer",
+            "cigarette",
+            "nicotine",
+            "smoking status",
+            "tobacco",
+            "smoking"
+        ]
+    },
+    "smoking-ban": {
+        "character": "\uf54d",
+        "searchterms": [
+            "ban",
+            "cancel",
+            "no smoking",
+            "non-smoking",
+            "smoking-ban"
+        ]
+    },
+    "sms": {
+        "character": "\uf7cd",
+        "searchterms": [
+            "chat",
+            "conversation",
+            "message",
+            "mobile",
+            "notification",
+            "phone",
+            "sms",
+            "texting"
+        ]
+    },
+    "snapchat": {
+        "character": "\uf2ab",
+        "searchterms": [
+            "snapchat"
+        ]
+    },
+    "snapchat-ghost": {
+        "character": "\uf2ac",
+        "searchterms": [
+            "snapchat-ghost"
+        ]
+    },
+    "snapchat-square": {
+        "character": "\uf2ad",
+        "searchterms": [
+            "snapchat-square"
+        ]
+    },
+    "snowboarding": {
+        "character": "\uf7ce",
+        "searchterms": [
+            "activity",
+            "fitness",
+            "olympics",
+            "outdoors",
+            "person",
+            "snowboarding"
+        ]
+    },
+    "snowflake": {
+        "character": "\uf2dc",
+        "searchterms": [
+            "precipitation",
+            "rain",
+            "winter",
+            "snowflake",
+            "snowflake-o"
+        ]
+    },
+    "snowflake-o": {
+        "character": "\uf2dc",
+        "searchterms": [
+            "precipitation",
+            "rain",
+            "winter",
+            "snowflake",
+            "snowflake-o"
+        ]
+    },
+    "snowman": {
+        "character": "\uf7d0",
+        "searchterms": [
+            "decoration",
+            "frost",
+            "frosty",
+            "holiday",
+            "snowman"
+        ]
+    },
+    "snowplow": {
+        "character": "\uf7d2",
+        "searchterms": [
+            "clean up",
+            "cold",
+            "road",
+            "storm",
+            "winter",
+            "snowplow"
+        ]
+    },
+    "soccer-ball-o": {
+        "character": "\uf1e3",
+        "searchterms": [
+            "ball",
+            "football",
+            "mls",
+            "soccer",
+            "futbol",
+            "futbol-o",
+            "soccer-ball-o"
+        ]
+    },
+    "socks": {
+        "character": "\uf696",
+        "searchterms": [
+            "business socks",
+            "business time",
+            "clothing",
+            "feet",
+            "flight of the conchords",
+            "wednesday",
+            "socks"
+        ]
+    },
+    "solar-panel": {
+        "character": "\uf5ba",
+        "searchterms": [
+            "clean",
+            "eco-friendly",
+            "energy",
+            "green",
+            "sun",
+            "solar-panel"
+        ]
+    },
+    "sort": {
+        "character": "\uf0dc",
+        "searchterms": [
+            "filter",
+            "order",
+            "sort",
+            "unsorted"
+        ]
+    },
+    "sort-alpha-asc": {
+        "character": "\uf15d",
+        "searchterms": [
+            "alphabetical",
+            "arrange",
+            "filter",
+            "order",
+            "sort-alpha-asc",
+            "sort-alpha-down"
+        ]
+    },
+    "sort-alpha-desc": {
+        "character": "\uf881",
+        "searchterms": [
+            "alphabetical",
+            "arrange",
+            "filter",
+            "order",
+            "sort-alpha-asc",
+            "sort-alpha-down-alt",
+            "sort-alpha-desc"
+        ]
+    },
+    "sort-alpha-down": {
+        "character": "\uf15d",
+        "searchterms": [
+            "alphabetical",
+            "arrange",
+            "filter",
+            "order",
+            "sort-alpha-asc",
+            "sort-alpha-down"
+        ]
+    },
+    "sort-alpha-down-alt": {
+        "character": "\uf881",
+        "searchterms": [
+            "alphabetical",
+            "arrange",
+            "filter",
+            "order",
+            "sort-alpha-asc",
+            "sort-alpha-down-alt",
+            "sort-alpha-desc"
+        ]
+    },
+    "sort-alpha-up": {
+        "character": "\uf15e",
+        "searchterms": [
+            "alphabetical",
+            "arrange",
+            "filter",
+            "order",
+            "sort-alpha-desc",
+            "sort-alpha-up"
+        ]
+    },
+    "sort-alpha-up-alt": {
+        "character": "\uf882",
+        "searchterms": [
+            "alphabetical",
+            "arrange",
+            "filter",
+            "order",
+            "sort-alpha-desc",
+            "sort-alpha-up-alt"
+        ]
+    },
+    "sort-amount-asc": {
+        "character": "\uf160",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "number",
+            "order",
+            "sort-amount-asc",
+            "sort-amount-down"
+        ]
+    },
+    "sort-amount-desc": {
+        "character": "\uf884",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "order",
+            "sort-amount-asc",
+            "sort-amount-down-alt",
+            "sort-amount-desc"
+        ]
+    },
+    "sort-amount-down": {
+        "character": "\uf160",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "number",
+            "order",
+            "sort-amount-asc",
+            "sort-amount-down"
+        ]
+    },
+    "sort-amount-down-alt": {
+        "character": "\uf884",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "order",
+            "sort-amount-asc",
+            "sort-amount-down-alt",
+            "sort-amount-desc"
+        ]
+    },
+    "sort-amount-up": {
+        "character": "\uf161",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "order",
+            "sort-amount-desc",
+            "sort-amount-up"
+        ]
+    },
+    "sort-amount-up-alt": {
+        "character": "\uf885",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "order",
+            "sort-amount-desc",
+            "sort-amount-up-alt"
+        ]
+    },
+    "sort-asc": {
+        "character": "\uf0de",
+        "searchterms": [
+            "arrow",
+            "ascending",
+            "filter",
+            "order",
+            "sort-asc",
+            "sort-up"
+        ]
+    },
+    "sort-desc": {
+        "character": "\uf0dd",
+        "searchterms": [
+            "arrow",
+            "descending",
+            "filter",
+            "order",
+            "sort-desc",
+            "sort-down"
+        ]
+    },
+    "sort-down": {
+        "character": "\uf0dd",
+        "searchterms": [
+            "arrow",
+            "descending",
+            "filter",
+            "order",
+            "sort-desc",
+            "sort-down"
+        ]
+    },
+    "sort-numeric-asc": {
+        "character": "\uf162",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "numbers",
+            "order",
+            "sort-numeric-asc",
+            "sort-numeric-down"
+        ]
+    },
+    "sort-numeric-desc": {
+        "character": "\uf886",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "numbers",
+            "order",
+            "sort-numeric-asc",
+            "sort-numeric-down-alt",
+            "sort-numeric-desc"
+        ]
+    },
+    "sort-numeric-down": {
+        "character": "\uf162",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "numbers",
+            "order",
+            "sort-numeric-asc",
+            "sort-numeric-down"
+        ]
+    },
+    "sort-numeric-down-alt": {
+        "character": "\uf886",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "numbers",
+            "order",
+            "sort-numeric-asc",
+            "sort-numeric-down-alt",
+            "sort-numeric-desc"
+        ]
+    },
+    "sort-numeric-up": {
+        "character": "\uf163",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "numbers",
+            "order",
+            "sort-numeric-desc",
+            "sort-numeric-up"
+        ]
+    },
+    "sort-numeric-up-alt": {
+        "character": "\uf887",
+        "searchterms": [
+            "arrange",
+            "filter",
+            "numbers",
+            "order",
+            "sort-numeric-desc",
+            "sort-numeric-up-alt"
+        ]
+    },
+    "sort-up": {
+        "character": "\uf0de",
+        "searchterms": [
+            "arrow",
+            "ascending",
+            "filter",
+            "order",
+            "sort-asc",
+            "sort-up"
+        ]
+    },
+    "soundcloud": {
+        "character": "\uf1be",
+        "searchterms": [
+            "soundcloud"
+        ]
+    },
+    "sourcetree": {
+        "character": "\uf7d3",
+        "searchterms": [
+            "sourcetree"
+        ]
+    },
+    "spa": {
+        "character": "\uf5bb",
+        "searchterms": [
+            "flora",
+            "massage",
+            "mindfulness",
+            "plant",
+            "wellness",
+            "spa"
+        ]
+    },
+    "space-shuttle": {
+        "character": "\uf197",
+        "searchterms": [
+            "astronaut",
+            "machine",
+            "nasa",
+            "rocket",
+            "space",
+            "transportation",
+            "space-shuttle"
+        ]
+    },
+    "speakap": {
+        "character": "\uf3f3",
+        "searchterms": [
+            "speakap"
+        ]
+    },
+    "speaker-deck": {
+        "character": "\uf83c",
+        "searchterms": [
+            "speaker-deck"
+        ]
+    },
+    "spell-check": {
+        "character": "\uf891",
+        "searchterms": [
+            "dictionary",
+            "edit",
+            "editor",
+            "grammar",
+            "text",
+            "spell-check"
+        ]
+    },
+    "spider": {
+        "character": "\uf717",
+        "searchterms": [
+            "arachnid",
+            "bug",
+            "charlotte",
+            "crawl",
+            "eight",
+            "halloween",
+            "spider"
+        ]
+    },
+    "spinner": {
+        "character": "\uf110",
+        "searchterms": [
+            "circle",
+            "loading",
+            "progress",
+            "spinner"
+        ]
+    },
+    "splotch": {
+        "character": "\uf5bc",
+        "searchterms": [
+            "Ink",
+            "blob",
+            "blotch",
+            "glob",
+            "stain",
+            "splotch"
+        ]
+    },
+    "spoon": {
+        "character": "\uf2e5",
+        "searchterms": [
+            "cutlery",
+            "dining",
+            "scoop",
+            "silverware",
+            "spoon",
+            "utensil-spoon"
+        ]
+    },
+    "spotify": {
+        "character": "\uf1bc",
+        "searchterms": [
+            "spotify"
+        ]
+    },
+    "spray-can": {
+        "character": "\uf5bd",
+        "searchterms": [
+            "Paint",
+            "aerosol",
+            "design",
+            "graffiti",
+            "tag",
+            "spray-can"
+        ]
+    },
+    "square": {
+        "character": "\uf0c8",
+        "searchterms": [
+            "block",
+            "box",
+            "shape",
+            "square",
+            "square-o"
+        ]
+    },
+    "square-full": {
+        "character": "\uf45c",
+        "searchterms": [
+            "block",
+            "box",
+            "shape",
+            "square-full"
+        ]
+    },
+    "square-o": {
+        "character": "\uf0c8",
+        "searchterms": [
+            "block",
+            "box",
+            "shape",
+            "square",
+            "square-o"
+        ]
+    },
+    "square-root-alt": {
+        "character": "\uf698",
+        "searchterms": [
+            "arithmetic",
+            "calculus",
+            "division",
+            "math",
+            "square-root-alt"
+        ]
+    },
+    "squarespace": {
+        "character": "\uf5be",
+        "searchterms": [
+            "squarespace"
+        ]
+    },
+    "stack-exchange": {
+        "character": "\uf18d",
+        "searchterms": [
+            "stack-exchange"
+        ]
+    },
+    "stack-overflow": {
+        "character": "\uf16c",
+        "searchterms": [
+            "stack-overflow"
+        ]
+    },
+    "stackpath": {
+        "character": "\uf842",
+        "searchterms": [
+            "stackpath"
+        ]
+    },
+    "stamp": {
+        "character": "\uf5bf",
+        "searchterms": [
+            "art",
+            "certificate",
+            "imprint",
+            "rubber",
+            "seal",
+            "stamp"
+        ]
+    },
+    "star": {
+        "character": "\uf005",
+        "searchterms": [
+            "achievement",
+            "award",
+            "favorite",
+            "important",
+            "night",
+            "rating",
+            "score",
+            "star",
+            "star-o"
+        ]
+    },
+    "star-and-crescent": {
+        "character": "\uf699",
+        "searchterms": [
+            "islam",
+            "muslim",
+            "religion",
+            "star-and-crescent"
+        ]
+    },
+    "star-half": {
+        "character": "\uf089",
+        "searchterms": [
+            "achievement",
+            "award",
+            "rating",
+            "score",
+            "star-half-empty",
+            "star-half-full",
+            "star-half",
+            "star-half-o"
+        ]
+    },
+    "star-half-alt": {
+        "character": "\uf5c0",
+        "searchterms": [
+            "achievement",
+            "award",
+            "rating",
+            "score",
+            "star-half-empty",
+            "star-half-full",
+            "star-half-alt"
+        ]
+    },
+    "star-half-empty": {
+        "character": "\uf089",
+        "searchterms": [
+            "achievement",
+            "award",
+            "rating",
+            "score",
+            "star-half-empty",
+            "star-half-full",
+            "star-half",
+            "star-half-o"
+        ]
+    },
+    "star-half-full": {
+        "character": "\uf089",
+        "searchterms": [
+            "achievement",
+            "award",
+            "rating",
+            "score",
+            "star-half-empty",
+            "star-half-full",
+            "star-half",
+            "star-half-o"
+        ]
+    },
+    "star-half-o": {
+        "character": "\uf089",
+        "searchterms": [
+            "achievement",
+            "award",
+            "rating",
+            "score",
+            "star-half-empty",
+            "star-half-full",
+            "star-half",
+            "star-half-o"
+        ]
+    },
+    "star-o": {
+        "character": "\uf005",
+        "searchterms": [
+            "achievement",
+            "award",
+            "favorite",
+            "important",
+            "night",
+            "rating",
+            "score",
+            "star",
+            "star-o"
+        ]
+    },
+    "star-of-david": {
+        "character": "\uf69a",
+        "searchterms": [
+            "jewish",
+            "judaism",
+            "religion",
+            "star-of-david"
+        ]
+    },
+    "star-of-life": {
+        "character": "\uf621",
+        "searchterms": [
+            "doctor",
+            "emt",
+            "first aid",
+            "health",
+            "medical",
+            "star-of-life"
+        ]
+    },
+    "staylinked": {
+        "character": "\uf3f5",
+        "searchterms": [
+            "staylinked"
+        ]
+    },
+    "steam": {
+        "character": "\uf1b6",
+        "searchterms": [
+            "steam"
+        ]
+    },
+    "steam-square": {
+        "character": "\uf1b7",
+        "searchterms": [
+            "steam-square"
+        ]
+    },
+    "steam-symbol": {
+        "character": "\uf3f6",
+        "searchterms": [
+            "steam-symbol"
+        ]
+    },
+    "step-backward": {
+        "character": "\uf048",
+        "searchterms": [
+            "beginning",
+            "first",
+            "previous",
+            "rewind",
+            "start",
+            "step-backward"
+        ]
+    },
+    "step-forward": {
+        "character": "\uf051",
+        "searchterms": [
+            "end",
+            "last",
+            "next",
+            "step-forward"
+        ]
+    },
+    "stethoscope": {
+        "character": "\uf0f1",
+        "searchterms": [
+            "covid-19",
+            "diagnosis",
+            "doctor",
+            "general practitioner",
+            "hospital",
+            "infirmary",
+            "medicine",
+            "office",
+            "outpatient",
+            "stethoscope"
+        ]
+    },
+    "sticker-mule": {
+        "character": "\uf3f7",
+        "searchterms": [
+            "sticker-mule"
+        ]
+    },
+    "sticky-note": {
+        "character": "\uf249",
+        "searchterms": [
+            "message",
+            "note",
+            "paper",
+            "reminder",
+            "sticker",
+            "sticky-note",
+            "sticky-note-o"
+        ]
+    },
+    "sticky-note-o": {
+        "character": "\uf249",
+        "searchterms": [
+            "message",
+            "note",
+            "paper",
+            "reminder",
+            "sticker",
+            "sticky-note",
+            "sticky-note-o"
+        ]
+    },
+    "stop": {
+        "character": "\uf04d",
+        "searchterms": [
+            "block",
+            "box",
+            "square",
+            "stop"
+        ]
+    },
+    "stop-circle": {
+        "character": "\uf28d",
+        "searchterms": [
+            "block",
+            "box",
+            "circle",
+            "square",
+            "stop-circle",
+            "stop-circle-o"
+        ]
+    },
+    "stop-circle-o": {
+        "character": "\uf28d",
+        "searchterms": [
+            "block",
+            "box",
+            "circle",
+            "square",
+            "stop-circle",
+            "stop-circle-o"
+        ]
+    },
+    "stopwatch": {
+        "character": "\uf2f2",
+        "searchterms": [
+            "clock",
+            "reminder",
+            "time",
+            "stopwatch"
+        ]
+    },
+    "store": {
+        "character": "\uf54e",
+        "searchterms": [
+            "building",
+            "buy",
+            "purchase",
+            "shopping",
+            "store"
+        ]
+    },
+    "store-alt": {
+        "character": "\uf54f",
+        "searchterms": [
+            "building",
+            "buy",
+            "purchase",
+            "shopping",
+            "store-alt"
+        ]
+    },
+    "strava": {
+        "character": "\uf428",
+        "searchterms": [
+            "strava"
+        ]
+    },
+    "stream": {
+        "character": "\uf550",
+        "searchterms": [
+            "flow",
+            "list",
+            "timeline",
+            "stream"
+        ]
+    },
+    "street-view": {
+        "character": "\uf21d",
+        "searchterms": [
+            "directions",
+            "location",
+            "map",
+            "navigation",
+            "street-view"
+        ]
+    },
+    "strikethrough": {
+        "character": "\uf0cc",
+        "searchterms": [
+            "cancel",
+            "edit",
+            "font",
+            "format",
+            "text",
+            "type",
+            "strikethrough"
+        ]
+    },
+    "stripe": {
+        "character": "\uf429",
+        "searchterms": [
+            "stripe"
+        ]
+    },
+    "stripe-s": {
+        "character": "\uf42a",
+        "searchterms": [
+            "stripe-s"
+        ]
+    },
+    "stroopwafel": {
+        "character": "\uf551",
+        "searchterms": [
+            "caramel",
+            "cookie",
+            "dessert",
+            "sweets",
+            "waffle",
+            "stroopwafel"
+        ]
+    },
+    "studiovinari": {
+        "character": "\uf3f8",
+        "searchterms": [
+            "studiovinari"
+        ]
+    },
+    "stumbleupon": {
+        "character": "\uf1a4",
+        "searchterms": [
+            "stumbleupon"
+        ]
+    },
+    "stumbleupon-circle": {
+        "character": "\uf1a3",
+        "searchterms": [
+            "stumbleupon-circle"
+        ]
+    },
+    "subscript": {
+        "character": "\uf12c",
+        "searchterms": [
+            "edit",
+            "font",
+            "format",
+            "text",
+            "type",
+            "subscript"
+        ]
+    },
+    "subway": {
+        "character": "\uf239",
+        "searchterms": [
+            "machine",
+            "railway",
+            "train",
+            "transportation",
+            "vehicle",
+            "subway"
+        ]
+    },
+    "suitcase": {
+        "character": "\uf0f2",
+        "searchterms": [
+            "baggage",
+            "luggage",
+            "move",
+            "suitcase",
+            "travel",
+            "trip"
+        ]
+    },
+    "suitcase-rolling": {
+        "character": "\uf5c1",
+        "searchterms": [
+            "baggage",
+            "luggage",
+            "move",
+            "suitcase",
+            "travel",
+            "trip",
+            "suitcase-rolling"
+        ]
+    },
+    "sun": {
+        "character": "\uf185",
+        "searchterms": [
+            "brighten",
+            "contrast",
+            "day",
+            "lighter",
+            "sol",
+            "solar",
+            "star",
+            "weather",
+            "sun",
+            "sun-o"
+        ]
+    },
+    "sun-o": {
+        "character": "\uf185",
+        "searchterms": [
+            "brighten",
+            "contrast",
+            "day",
+            "lighter",
+            "sol",
+            "solar",
+            "star",
+            "weather",
+            "sun",
+            "sun-o"
+        ]
+    },
+    "superpowers": {
+        "character": "\uf2dd",
+        "searchterms": [
+            "superpowers"
+        ]
+    },
+    "superscript": {
+        "character": "\uf12b",
+        "searchterms": [
+            "edit",
+            "exponential",
+            "font",
+            "format",
+            "text",
+            "type",
+            "superscript"
+        ]
+    },
+    "supple": {
+        "character": "\uf3f9",
+        "searchterms": [
+            "supple"
+        ]
+    },
+    "support": {
+        "character": "\uf1cd",
+        "searchterms": [
+            "coast guard",
+            "help",
+            "overboard",
+            "save",
+            "support",
+            "life-ring",
+            "life-bouy",
+            "life-buoy",
+            "life-saver"
+        ]
+    },
+    "surprise": {
+        "character": "\uf5c2",
+        "searchterms": [
+            "emoticon",
+            "face",
+            "shocked",
+            "surprise"
+        ]
+    },
+    "suse": {
+        "character": "\uf7d6",
+        "searchterms": [
+            "linux",
+            "operating system",
+            "os",
+            "suse"
+        ]
+    },
+    "swatchbook": {
+        "character": "\uf5c3",
+        "searchterms": [
+            "Pantone",
+            "color",
+            "design",
+            "hue",
+            "palette",
+            "swatchbook"
+        ]
+    },
+    "swift": {
+        "character": "\uf8e1",
+        "searchterms": [
+            "swift"
+        ]
+    },
+    "swimmer": {
+        "character": "\uf5c4",
+        "searchterms": [
+            "athlete",
+            "head",
+            "man",
+            "olympics",
+            "person",
+            "pool",
+            "water",
+            "swimmer"
+        ]
+    },
+    "swimming-pool": {
+        "character": "\uf5c5",
+        "searchterms": [
+            "ladder",
+            "recreation",
+            "swim",
+            "water",
+            "swimming-pool"
+        ]
+    },
+    "symfony": {
+        "character": "\uf83d",
+        "searchterms": [
+            "symfony"
+        ]
+    },
+    "synagogue": {
+        "character": "\uf69b",
+        "searchterms": [
+            "building",
+            "jewish",
+            "judaism",
+            "religion",
+            "star of david",
+            "temple",
+            "synagogue"
+        ]
+    },
+    "sync": {
+        "character": "\uf021",
+        "searchterms": [
+            "exchange",
+            "refresh",
+            "reload",
+            "rotate",
+            "swap",
+            "sync"
+        ]
+    },
+    "sync-alt": {
+        "character": "\uf2f1",
+        "searchterms": [
+            "exchange",
+            "refresh",
+            "reload",
+            "rotate",
+            "swap",
+            "sync-alt"
+        ]
+    },
+    "syringe": {
+        "character": "\uf48e",
+        "searchterms": [
+            "covid-19",
+            "doctor",
+            "immunizations",
+            "medical",
+            "needle",
+            "syringe"
+        ]
+    },
+    "table": {
+        "character": "\uf0ce",
+        "searchterms": [
+            "data",
+            "excel",
+            "spreadsheet",
+            "table"
+        ]
+    },
+    "table-tennis": {
+        "character": "\uf45d",
+        "searchterms": [
+            "ball",
+            "paddle",
+            "ping pong",
+            "table-tennis"
+        ]
+    },
+    "tablet": {
+        "character": "\uf10a",
+        "searchterms": [
+            "apple",
+            "device",
+            "ipad",
+            "kindle",
+            "screen",
+            "tablet"
+        ]
+    },
+    "tablet-alt": {
+        "character": "\uf3fa",
+        "searchterms": [
+            "apple",
+            "device",
+            "ipad",
+            "kindle",
+            "screen",
+            "tablet-alt"
+        ]
+    },
+    "tablets": {
+        "character": "\uf490",
+        "searchterms": [
+            "drugs",
+            "medicine",
+            "pills",
+            "prescription",
+            "tablets"
+        ]
+    },
+    "tachometer": {
+        "character": "\uf3fd",
+        "searchterms": [
+            "dashboard",
+            "fast",
+            "odometer",
+            "speed",
+            "speedometer",
+            "tachometer-alt",
+            "tachometer"
+        ]
+    },
+    "tachometer-alt": {
+        "character": "\uf3fd",
+        "searchterms": [
+            "dashboard",
+            "fast",
+            "odometer",
+            "speed",
+            "speedometer",
+            "tachometer-alt",
+            "tachometer"
+        ]
+    },
+    "tag": {
+        "character": "\uf02b",
+        "searchterms": [
+            "discount",
+            "label",
+            "price",
+            "shopping",
+            "tag"
+        ]
+    },
+    "tags": {
+        "character": "\uf02c",
+        "searchterms": [
+            "discount",
+            "label",
+            "price",
+            "shopping",
+            "tags"
+        ]
+    },
+    "tape": {
+        "character": "\uf4db",
+        "searchterms": [
+            "design",
+            "package",
+            "sticky",
+            "tape"
+        ]
+    },
+    "tasks": {
+        "character": "\uf0ae",
+        "searchterms": [
+            "checklist",
+            "downloading",
+            "downloads",
+            "loading",
+            "progress",
+            "project management",
+            "settings",
+            "to do",
+            "tasks"
+        ]
+    },
+    "taxi": {
+        "character": "\uf1ba",
+        "searchterms": [
+            "cab",
+            "cabbie",
+            "car",
+            "car service",
+            "lyft",
+            "machine",
+            "transportation",
+            "travel",
+            "uber",
+            "vehicle",
+            "taxi"
+        ]
+    },
+    "teamspeak": {
+        "character": "\uf4f9",
+        "searchterms": [
+            "teamspeak"
+        ]
+    },
+    "teeth": {
+        "character": "\uf62e",
+        "searchterms": [
+            "bite",
+            "dental",
+            "dentist",
+            "gums",
+            "mouth",
+            "smile",
+            "tooth",
+            "teeth"
+        ]
+    },
+    "teeth-open": {
+        "character": "\uf62f",
+        "searchterms": [
+            "dental",
+            "dentist",
+            "gums bite",
+            "mouth",
+            "smile",
+            "tooth",
+            "teeth-open"
+        ]
+    },
+    "telegram": {
+        "character": "\uf2c6",
+        "searchterms": [
+            "telegram"
+        ]
+    },
+    "telegram-plane": {
+        "character": "\uf3fe",
+        "searchterms": [
+            "telegram-plane"
+        ]
+    },
+    "television": {
+        "character": "\uf26c",
+        "searchterms": [
+            "computer",
+            "display",
+            "monitor",
+            "television",
+            "tv"
+        ]
+    },
+    "temperature-high": {
+        "character": "\uf769",
+        "searchterms": [
+            "cook",
+            "covid-19",
+            "mercury",
+            "summer",
+            "thermometer",
+            "warm",
+            "temperature-high"
+        ]
+    },
+    "temperature-low": {
+        "character": "\uf76b",
+        "searchterms": [
+            "cold",
+            "cool",
+            "covid-19",
+            "mercury",
+            "thermometer",
+            "winter",
+            "temperature-low"
+        ]
+    },
+    "tencent-weibo": {
+        "character": "\uf1d5",
+        "searchterms": [
+            "tencent-weibo"
+        ]
+    },
+    "tenge": {
+        "character": "\uf7d7",
+        "searchterms": [
+            "currency",
+            "kazakhstan",
+            "money",
+            "price",
+            "tenge"
+        ]
+    },
+    "terminal": {
+        "character": "\uf120",
+        "searchterms": [
+            "code",
+            "command",
+            "console",
+            "development",
+            "prompt",
+            "terminal"
+        ]
+    },
+    "text-height": {
+        "character": "\uf034",
+        "searchterms": [
+            "edit",
+            "font",
+            "format",
+            "text",
+            "type",
+            "text-height"
+        ]
+    },
+    "text-width": {
+        "character": "\uf035",
+        "searchterms": [
+            "edit",
+            "font",
+            "format",
+            "text",
+            "type",
+            "text-width"
+        ]
+    },
+    "th": {
+        "character": "\uf00a",
+        "searchterms": [
+            "blocks",
+            "boxes",
+            "grid",
+            "squares",
+            "th"
+        ]
+    },
+    "th-large": {
+        "character": "\uf009",
+        "searchterms": [
+            "blocks",
+            "boxes",
+            "grid",
+            "squares",
+            "th-large"
+        ]
+    },
+    "th-list": {
+        "character": "\uf00b",
+        "searchterms": [
+            "checklist",
+            "completed",
+            "done",
+            "finished",
+            "ol",
+            "todo",
+            "ul",
+            "th-list"
+        ]
+    },
+    "the-red-yeti": {
+        "character": "\uf69d",
+        "searchterms": [
+            "the-red-yeti"
+        ]
+    },
+    "theater-masks": {
+        "character": "\uf630",
+        "searchterms": [
+            "comedy",
+            "perform",
+            "theatre",
+            "tragedy",
+            "theater-masks"
+        ]
+    },
+    "themeco": {
+        "character": "\uf5c6",
+        "searchterms": [
+            "themeco"
+        ]
+    },
+    "themeisle": {
+        "character": "\uf2b2",
+        "searchterms": [
+            "themeisle"
+        ]
+    },
+    "thermometer": {
+        "character": "\uf491",
+        "searchterms": [
+            "covid-19",
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer"
+        ]
+    },
+    "thermometer-0": {
+        "character": "\uf2cb",
+        "searchterms": [
+            "cold",
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-empty",
+            "thermometer-0"
+        ]
+    },
+    "thermometer-1": {
+        "character": "\uf2ca",
+        "searchterms": [
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-quarter",
+            "thermometer-1"
+        ]
+    },
+    "thermometer-2": {
+        "character": "\uf2c9",
+        "searchterms": [
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-half",
+            "thermometer-2"
+        ]
+    },
+    "thermometer-3": {
+        "character": "\uf2c8",
+        "searchterms": [
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-three-quarters",
+            "thermometer-3"
+        ]
+    },
+    "thermometer-4": {
+        "character": "\uf2c7",
+        "searchterms": [
+            "fever",
+            "hot",
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-full",
+            "thermometer-4"
+        ]
+    },
+    "thermometer-empty": {
+        "character": "\uf2cb",
+        "searchterms": [
+            "cold",
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-empty",
+            "thermometer-0"
+        ]
+    },
+    "thermometer-full": {
+        "character": "\uf2c7",
+        "searchterms": [
+            "fever",
+            "hot",
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-full",
+            "thermometer-4"
+        ]
+    },
+    "thermometer-half": {
+        "character": "\uf2c9",
+        "searchterms": [
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-half",
+            "thermometer-2"
+        ]
+    },
+    "thermometer-quarter": {
+        "character": "\uf2ca",
+        "searchterms": [
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-quarter",
+            "thermometer-1"
+        ]
+    },
+    "thermometer-three-quarters": {
+        "character": "\uf2c8",
+        "searchterms": [
+            "mercury",
+            "status",
+            "temperature",
+            "thermometer-three-quarters",
+            "thermometer-3"
+        ]
+    },
+    "think-peaks": {
+        "character": "\uf731",
+        "searchterms": [
+            "think-peaks"
+        ]
+    },
+    "thumb-tack": {
+        "character": "\uf08d",
+        "searchterms": [
+            "coordinates",
+            "location",
+            "marker",
+            "pin",
+            "thumb-tack",
+            "thumbtack"
+        ]
+    },
+    "thumbs-down": {
+        "character": "\uf165",
+        "searchterms": [
+            "disagree",
+            "disapprove",
+            "dislike",
+            "hand",
+            "social",
+            "thumbs-o-down",
+            "thumbs-down"
+        ]
+    },
+    "thumbs-o-down": {
+        "character": "\uf165",
+        "searchterms": [
+            "disagree",
+            "disapprove",
+            "dislike",
+            "hand",
+            "social",
+            "thumbs-o-down",
+            "thumbs-down"
+        ]
+    },
+    "thumbs-o-up": {
+        "character": "\uf164",
+        "searchterms": [
+            "agree",
+            "approve",
+            "favorite",
+            "hand",
+            "like",
+            "ok",
+            "okay",
+            "social",
+            "success",
+            "thumbs-o-up",
+            "yes",
+            "you got it dude",
+            "thumbs-up"
+        ]
+    },
+    "thumbs-up": {
+        "character": "\uf164",
+        "searchterms": [
+            "agree",
+            "approve",
+            "favorite",
+            "hand",
+            "like",
+            "ok",
+            "okay",
+            "social",
+            "success",
+            "thumbs-o-up",
+            "yes",
+            "you got it dude",
+            "thumbs-up"
+        ]
+    },
+    "thumbtack": {
+        "character": "\uf08d",
+        "searchterms": [
+            "coordinates",
+            "location",
+            "marker",
+            "pin",
+            "thumb-tack",
+            "thumbtack"
+        ]
+    },
+    "ticket": {
+        "character": "\uf3ff",
+        "searchterms": [
+            "movie",
+            "pass",
+            "support",
+            "ticket",
+            "ticket-alt"
+        ]
+    },
+    "ticket-alt": {
+        "character": "\uf3ff",
+        "searchterms": [
+            "movie",
+            "pass",
+            "support",
+            "ticket",
+            "ticket-alt"
+        ]
+    },
+    "times": {
+        "character": "\uf00d",
+        "searchterms": [
+            "close",
+            "cross",
+            "error",
+            "exit",
+            "incorrect",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "wrong",
+            "x",
+            "times",
+            "remove"
+        ]
+    },
+    "times-circle": {
+        "character": "\uf057",
+        "searchterms": [
+            "close",
+            "cross",
+            "exit",
+            "incorrect",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "wrong",
+            "x",
+            "times-circle",
+            "times-circle-o"
+        ]
+    },
+    "times-circle-o": {
+        "character": "\uf057",
+        "searchterms": [
+            "close",
+            "cross",
+            "exit",
+            "incorrect",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "wrong",
+            "x",
+            "times-circle",
+            "times-circle-o"
+        ]
+    },
+    "times-rectangle": {
+        "character": "\uf410",
+        "searchterms": [
+            "browser",
+            "cancel",
+            "computer",
+            "development",
+            "window-close",
+            "times-rectangle",
+            "window-close-o",
+            "times-rectangle-o"
+        ]
+    },
+    "times-rectangle-o": {
+        "character": "\uf410",
+        "searchterms": [
+            "browser",
+            "cancel",
+            "computer",
+            "development",
+            "window-close",
+            "times-rectangle",
+            "window-close-o",
+            "times-rectangle-o"
+        ]
+    },
+    "tint": {
+        "character": "\uf043",
+        "searchterms": [
+            "color",
+            "drop",
+            "droplet",
+            "raindrop",
+            "waterdrop",
+            "tint"
+        ]
+    },
+    "tint-slash": {
+        "character": "\uf5c7",
+        "searchterms": [
+            "color",
+            "drop",
+            "droplet",
+            "raindrop",
+            "waterdrop",
+            "tint-slash"
+        ]
+    },
+    "tired": {
+        "character": "\uf5c8",
+        "searchterms": [
+            "angry",
+            "emoticon",
+            "face",
+            "grumpy",
+            "upset",
+            "tired"
+        ]
+    },
+    "toggle-down": {
+        "character": "\uf150",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-down",
+            "dropdown",
+            "expand",
+            "menu",
+            "more",
+            "triangle",
+            "caret-square-down",
+            "toggle-down"
+        ]
+    },
+    "toggle-left": {
+        "character": "\uf191",
+        "searchterms": [
+            "arrow",
+            "back",
+            "caret-square-o-left",
+            "previous",
+            "triangle",
+            "caret-square-left",
+            "toggle-left"
+        ]
+    },
+    "toggle-off": {
+        "character": "\uf204",
+        "searchterms": [
+            "switch",
+            "toggle-off"
+        ]
+    },
+    "toggle-on": {
+        "character": "\uf205",
+        "searchterms": [
+            "switch",
+            "toggle-on"
+        ]
+    },
+    "toggle-right": {
+        "character": "\uf152",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-right",
+            "forward",
+            "next",
+            "triangle",
+            "caret-square-right",
+            "toggle-right"
+        ]
+    },
+    "toggle-up": {
+        "character": "\uf151",
+        "searchterms": [
+            "arrow",
+            "caret-square-o-up",
+            "collapse",
+            "triangle",
+            "upload",
+            "caret-square-up",
+            "toggle-up"
+        ]
+    },
+    "toilet": {
+        "character": "\uf7d8",
+        "searchterms": [
+            "bathroom",
+            "flush",
+            "john",
+            "loo",
+            "pee",
+            "plumbing",
+            "poop",
+            "porcelain",
+            "potty",
+            "restroom",
+            "throne",
+            "washroom",
+            "waste",
+            "wc",
+            "toilet"
+        ]
+    },
+    "toilet-paper": {
+        "character": "\uf71e",
+        "searchterms": [
+            "bathroom",
+            "covid-19",
+            "halloween",
+            "holiday",
+            "lavatory",
+            "prank",
+            "restroom",
+            "roll",
+            "toilet-paper"
+        ]
+    },
+    "toolbox": {
+        "character": "\uf552",
+        "searchterms": [
+            "admin",
+            "container",
+            "fix",
+            "repair",
+            "settings",
+            "tools",
+            "toolbox"
+        ]
+    },
+    "tools": {
+        "character": "\uf7d9",
+        "searchterms": [
+            "admin",
+            "fix",
+            "repair",
+            "screwdriver",
+            "settings",
+            "tools",
+            "wrench"
+        ]
+    },
+    "tooth": {
+        "character": "\uf5c9",
+        "searchterms": [
+            "bicuspid",
+            "dental",
+            "dentist",
+            "molar",
+            "mouth",
+            "teeth",
+            "tooth"
+        ]
+    },
+    "torah": {
+        "character": "\uf6a0",
+        "searchterms": [
+            "book",
+            "jewish",
+            "judaism",
+            "religion",
+            "scroll",
+            "torah"
+        ]
+    },
+    "torii-gate": {
+        "character": "\uf6a1",
+        "searchterms": [
+            "building",
+            "shintoism",
+            "torii-gate"
+        ]
+    },
+    "tractor": {
+        "character": "\uf722",
+        "searchterms": [
+            "agriculture",
+            "farm",
+            "vehicle",
+            "tractor"
+        ]
+    },
+    "trade-federation": {
+        "character": "\uf513",
+        "searchterms": [
+            "trade-federation"
+        ]
+    },
+    "trademark": {
+        "character": "\uf25c",
+        "searchterms": [
+            "copyright",
+            "register",
+            "symbol",
+            "trademark"
+        ]
+    },
+    "traffic-light": {
+        "character": "\uf637",
+        "searchterms": [
+            "direction",
+            "road",
+            "signal",
+            "travel",
+            "traffic-light"
+        ]
+    },
+    "train": {
+        "character": "\uf238",
+        "searchterms": [
+            "bullet",
+            "commute",
+            "locomotive",
+            "railway",
+            "subway",
+            "train"
+        ]
+    },
+    "tram": {
+        "character": "\uf7da",
+        "searchterms": [
+            "crossing",
+            "machine",
+            "mountains",
+            "seasonal",
+            "transportation",
+            "tram"
+        ]
+    },
+    "transgender": {
+        "character": "\uf224",
+        "searchterms": [
+            "intersex",
+            "transgender"
+        ]
+    },
+    "transgender-alt": {
+        "character": "\uf225",
+        "searchterms": [
+            "intersex",
+            "transgender-alt"
+        ]
+    },
+    "trash": {
+        "character": "\uf1f8",
+        "searchterms": [
+            "delete",
+            "garbage",
+            "hide",
+            "remove",
+            "trash"
+        ]
+    },
+    "trash-alt": {
+        "character": "\uf2ed",
+        "searchterms": [
+            "delete",
+            "garbage",
+            "hide",
+            "remove",
+            "trash-o",
+            "trash-alt"
+        ]
+    },
+    "trash-o": {
+        "character": "\uf2ed",
+        "searchterms": [
+            "delete",
+            "garbage",
+            "hide",
+            "remove",
+            "trash-o",
+            "trash-alt"
+        ]
+    },
+    "trash-restore": {
+        "character": "\uf829",
+        "searchterms": [
+            "back",
+            "control z",
+            "oops",
+            "undo",
+            "trash-restore"
+        ]
+    },
+    "trash-restore-alt": {
+        "character": "\uf82a",
+        "searchterms": [
+            "back",
+            "control z",
+            "oops",
+            "undo",
+            "trash-restore-alt"
+        ]
+    },
+    "tree": {
+        "character": "\uf1bb",
+        "searchterms": [
+            "bark",
+            "fall",
+            "flora",
+            "forest",
+            "nature",
+            "plant",
+            "seasonal",
+            "tree"
+        ]
+    },
+    "trello": {
+        "character": "\uf181",
+        "searchterms": [
+            "atlassian",
+            "trello"
+        ]
+    },
+    "tripadvisor": {
+        "character": "\uf262",
+        "searchterms": [
+            "tripadvisor"
+        ]
+    },
+    "trophy": {
+        "character": "\uf091",
+        "searchterms": [
+            "achievement",
+            "award",
+            "cup",
+            "game",
+            "winner",
+            "trophy"
+        ]
+    },
+    "truck": {
+        "character": "\uf0d1",
+        "searchterms": [
+            "cargo",
+            "delivery",
+            "shipping",
+            "vehicle",
+            "truck"
+        ]
+    },
+    "truck-loading": {
+        "character": "\uf4de",
+        "searchterms": [
+            "box",
+            "cargo",
+            "delivery",
+            "inventory",
+            "moving",
+            "rental",
+            "vehicle",
+            "truck-loading"
+        ]
+    },
+    "truck-monster": {
+        "character": "\uf63b",
+        "searchterms": [
+            "offroad",
+            "vehicle",
+            "wheel",
+            "truck-monster"
+        ]
+    },
+    "truck-moving": {
+        "character": "\uf4df",
+        "searchterms": [
+            "cargo",
+            "inventory",
+            "rental",
+            "vehicle",
+            "truck-moving"
+        ]
+    },
+    "truck-pickup": {
+        "character": "\uf63c",
+        "searchterms": [
+            "cargo",
+            "vehicle",
+            "truck-pickup"
+        ]
+    },
+    "try": {
+        "character": "\uf195",
+        "searchterms": [
+            "currency",
+            "money",
+            "try",
+            "turkish",
+            "lira-sign",
+            "turkish-lira"
+        ]
+    },
+    "tshirt": {
+        "character": "\uf553",
+        "searchterms": [
+            "clothing",
+            "fashion",
+            "garment",
+            "shirt",
+            "tshirt"
+        ]
+    },
+    "tty": {
+        "character": "\uf1e4",
+        "searchterms": [
+            "communication",
+            "deaf",
+            "telephone",
+            "teletypewriter",
+            "text",
+            "tty"
+        ]
+    },
+    "tumblr": {
+        "character": "\uf173",
+        "searchterms": [
+            "tumblr"
+        ]
+    },
+    "tumblr-square": {
+        "character": "\uf174",
+        "searchterms": [
+            "tumblr-square"
+        ]
+    },
+    "turkish-lira": {
+        "character": "\uf195",
+        "searchterms": [
+            "currency",
+            "money",
+            "try",
+            "turkish",
+            "lira-sign",
+            "turkish-lira"
+        ]
+    },
+    "tv": {
+        "character": "\uf26c",
+        "searchterms": [
+            "computer",
+            "display",
+            "monitor",
+            "television",
+            "tv"
+        ]
+    },
+    "twitch": {
+        "character": "\uf1e8",
+        "searchterms": [
+            "twitch"
+        ]
+    },
+    "twitter": {
+        "character": "\uf099",
+        "searchterms": [
+            "social network",
+            "tweet",
+            "twitter"
+        ]
+    },
+    "twitter-square": {
+        "character": "\uf081",
+        "searchterms": [
+            "social network",
+            "tweet",
+            "twitter-square"
+        ]
+    },
+    "typo3": {
+        "character": "\uf42b",
+        "searchterms": [
+            "typo3"
+        ]
+    },
+    "uber": {
+        "character": "\uf402",
+        "searchterms": [
+            "uber"
+        ]
+    },
+    "ubuntu": {
+        "character": "\uf7df",
+        "searchterms": [
+            "linux",
+            "operating system",
+            "os",
+            "ubuntu"
+        ]
+    },
+    "uikit": {
+        "character": "\uf403",
+        "searchterms": [
+            "uikit"
+        ]
+    },
+    "umbraco": {
+        "character": "\uf8e8",
+        "searchterms": [
+            "umbraco"
+        ]
+    },
+    "umbrelbeach": {
+        "character": "\uf5ca",
+        "searchterms": [
+            "protection",
+            "recreation",
+            "sand",
+            "shade",
+            "summer",
+            "sun",
+            "umbrelbeach"
+        ]
+    },
+    "umbrella": {
+        "character": "\uf0e9",
+        "searchterms": [
+            "protection",
+            "rain",
+            "storm",
+            "wet",
+            "umbrella"
+        ]
+    },
+    "underline": {
+        "character": "\uf0cd",
+        "searchterms": [
+            "edit",
+            "emphasis",
+            "format",
+            "text",
+            "writing",
+            "underline"
+        ]
+    },
+    "undo": {
+        "character": "\uf0e2",
+        "searchterms": [
+            "back",
+            "control z",
+            "exchange",
+            "oops",
+            "return",
+            "rotate",
+            "swap",
+            "undo",
+            "rotate-left"
+        ]
+    },
+    "undo-alt": {
+        "character": "\uf2ea",
+        "searchterms": [
+            "back",
+            "control z",
+            "exchange",
+            "oops",
+            "return",
+            "swap",
+            "undo-alt"
+        ]
+    },
+    "uniregistry": {
+        "character": "\uf404",
+        "searchterms": [
+            "uniregistry"
+        ]
+    },
+    "universal-access": {
+        "character": "\uf29a",
+        "searchterms": [
+            "accessibility",
+            "hearing",
+            "person",
+            "seeing",
+            "visual impairment",
+            "universal-access"
+        ]
+    },
+    "university": {
+        "character": "\uf19c",
+        "searchterms": [
+            "bank",
+            "building",
+            "college",
+            "higher education - students",
+            "institution",
+            "university"
+        ]
+    },
+    "unlink": {
+        "character": "\uf127",
+        "searchterms": [
+            "attachment",
+            "chain",
+            "chain-broken",
+            "remove",
+            "unlink"
+        ]
+    },
+    "unlock": {
+        "character": "\uf09c",
+        "searchterms": [
+            "admin",
+            "lock",
+            "password",
+            "private",
+            "protect",
+            "unlock"
+        ]
+    },
+    "unlock-alt": {
+        "character": "\uf13e",
+        "searchterms": [
+            "admin",
+            "lock",
+            "password",
+            "private",
+            "protect",
+            "unlock-alt"
+        ]
+    },
+    "unsorted": {
+        "character": "\uf0dc",
+        "searchterms": [
+            "filter",
+            "order",
+            "sort",
+            "unsorted"
+        ]
+    },
+    "untappd": {
+        "character": "\uf405",
+        "searchterms": [
+            "untappd"
+        ]
+    },
+    "upload": {
+        "character": "\uf093",
+        "searchterms": [
+            "hard drive",
+            "import",
+            "publish",
+            "upload"
+        ]
+    },
+    "ups": {
+        "character": "\uf7e0",
+        "searchterms": [
+            "United Parcel Service",
+            "package",
+            "shipping",
+            "ups"
+        ]
+    },
+    "usb": {
+        "character": "\uf287",
+        "searchterms": [
+            "usb"
+        ]
+    },
+    "usd": {
+        "character": "\uf155",
+        "searchterms": [
+            "$",
+            "cost",
+            "dollar-sign",
+            "money",
+            "price",
+            "usd",
+            "dollar"
+        ]
+    },
+    "user": {
+        "character": "\uf007",
+        "searchterms": [
+            "account",
+            "avatar",
+            "head",
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user",
+            "user-o"
+        ]
+    },
+    "user-alt": {
+        "character": "\uf406",
+        "searchterms": [
+            "account",
+            "avatar",
+            "head",
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user-alt"
+        ]
+    },
+    "user-alt-slash": {
+        "character": "\uf4fa",
+        "searchterms": [
+            "account",
+            "avatar",
+            "head",
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user-alt-slash"
+        ]
+    },
+    "user-astronaut": {
+        "character": "\uf4fb",
+        "searchterms": [
+            "avatar",
+            "clothing",
+            "cosmonaut",
+            "nasa",
+            "space",
+            "suit",
+            "user-astronaut"
+        ]
+    },
+    "user-check": {
+        "character": "\uf4fc",
+        "searchterms": [
+            "accept",
+            "check",
+            "person",
+            "verified",
+            "user-check"
+        ]
+    },
+    "user-circle": {
+        "character": "\uf2bd",
+        "searchterms": [
+            "account",
+            "avatar",
+            "head",
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user-circle",
+            "user-circle-o"
+        ]
+    },
+    "user-circle-o": {
+        "character": "\uf2bd",
+        "searchterms": [
+            "account",
+            "avatar",
+            "head",
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user-circle",
+            "user-circle-o"
+        ]
+    },
+    "user-clock": {
+        "character": "\uf4fd",
+        "searchterms": [
+            "alert",
+            "person",
+            "remind",
+            "time",
+            "user-clock"
+        ]
+    },
+    "user-cog": {
+        "character": "\uf4fe",
+        "searchterms": [
+            "admin",
+            "cog",
+            "person",
+            "settings",
+            "user-cog"
+        ]
+    },
+    "user-edit": {
+        "character": "\uf4ff",
+        "searchterms": [
+            "edit",
+            "pen",
+            "pencil",
+            "person",
+            "update",
+            "write",
+            "user-edit"
+        ]
+    },
+    "user-friends": {
+        "character": "\uf500",
+        "searchterms": [
+            "group",
+            "people",
+            "person",
+            "team",
+            "users",
+            "user-friends"
+        ]
+    },
+    "user-graduate": {
+        "character": "\uf501",
+        "searchterms": [
+            "cap",
+            "clothing",
+            "commencement",
+            "gown",
+            "graduation",
+            "person",
+            "student",
+            "user-graduate"
+        ]
+    },
+    "user-injured": {
+        "character": "\uf728",
+        "searchterms": [
+            "cast",
+            "injury",
+            "ouch",
+            "patient",
+            "person",
+            "sling",
+            "user-injured"
+        ]
+    },
+    "user-lock": {
+        "character": "\uf502",
+        "searchterms": [
+            "admin",
+            "lock",
+            "person",
+            "private",
+            "unlock",
+            "user-lock"
+        ]
+    },
+    "user-md": {
+        "character": "\uf0f0",
+        "searchterms": [
+            "covid-19",
+            "job",
+            "medical",
+            "nurse",
+            "occupation",
+            "physician",
+            "profile",
+            "surgeon",
+            "user-md"
+        ]
+    },
+    "user-minus": {
+        "character": "\uf503",
+        "searchterms": [
+            "delete",
+            "negative",
+            "remove",
+            "user-minus"
+        ]
+    },
+    "user-ninja": {
+        "character": "\uf504",
+        "searchterms": [
+            "assassin",
+            "avatar",
+            "dangerous",
+            "deadly",
+            "sneaky",
+            "user-ninja"
+        ]
+    },
+    "user-nurse": {
+        "character": "\uf82f",
+        "searchterms": [
+            "covid-19",
+            "doctor",
+            "midwife",
+            "practitioner",
+            "surgeon",
+            "user-nurse"
+        ]
+    },
+    "user-o": {
+        "character": "\uf007",
+        "searchterms": [
+            "account",
+            "avatar",
+            "head",
+            "human",
+            "man",
+            "person",
+            "profile",
+            "user",
+            "user-o"
+        ]
+    },
+    "user-plus": {
+        "character": "\uf234",
+        "searchterms": [
+            "add",
+            "avatar",
+            "positive",
+            "sign up",
+            "signup",
+            "team",
+            "user-plus"
+        ]
+    },
+    "user-secret": {
+        "character": "\uf21b",
+        "searchterms": [
+            "clothing",
+            "coat",
+            "hat",
+            "incognito",
+            "person",
+            "privacy",
+            "spy",
+            "whisper",
+            "user-secret"
+        ]
+    },
+    "user-shield": {
+        "character": "\uf505",
+        "searchterms": [
+            "admin",
+            "person",
+            "private",
+            "protect",
+            "safe",
+            "user-shield"
+        ]
+    },
+    "user-slash": {
+        "character": "\uf506",
+        "searchterms": [
+            "ban",
+            "delete",
+            "remove",
+            "user-slash"
+        ]
+    },
+    "user-tag": {
+        "character": "\uf507",
+        "searchterms": [
+            "avatar",
+            "discount",
+            "label",
+            "person",
+            "role",
+            "special",
+            "user-tag"
+        ]
+    },
+    "user-tie": {
+        "character": "\uf508",
+        "searchterms": [
+            "avatar",
+            "business",
+            "clothing",
+            "formal",
+            "professional",
+            "suit",
+            "user-tie"
+        ]
+    },
+    "user-times": {
+        "character": "\uf235",
+        "searchterms": [
+            "archive",
+            "delete",
+            "remove",
+            "x",
+            "user-times"
+        ]
+    },
+    "users": {
+        "character": "\uf0c0",
+        "searchterms": [
+            "friends",
+            "group",
+            "people",
+            "persons",
+            "profiles",
+            "team",
+            "users"
+        ]
+    },
+    "users-cog": {
+        "character": "\uf509",
+        "searchterms": [
+            "admin",
+            "cog",
+            "group",
+            "person",
+            "settings",
+            "team",
+            "users-cog"
+        ]
+    },
+    "usps": {
+        "character": "\uf7e1",
+        "searchterms": [
+            "american",
+            "package",
+            "shipping",
+            "usa",
+            "usps"
+        ]
+    },
+    "ussunnah": {
+        "character": "\uf407",
+        "searchterms": [
+            "ussunnah"
+        ]
+    },
+    "utensil-spoon": {
+        "character": "\uf2e5",
+        "searchterms": [
+            "cutlery",
+            "dining",
+            "scoop",
+            "silverware",
+            "spoon",
+            "utensil-spoon"
+        ]
+    },
+    "utensils": {
+        "character": "\uf2e7",
+        "searchterms": [
+            "cutlery",
+            "dining",
+            "dinner",
+            "eat",
+            "food",
+            "fork",
+            "knife",
+            "restaurant",
+            "utensils"
+        ]
+    },
+    "vaadin": {
+        "character": "\uf408",
+        "searchterms": [
+            "vaadin"
+        ]
+    },
+    "vcard": {
+        "character": "\uf2bb",
+        "searchterms": [
+            "about",
+            "contact",
+            "id",
+            "identification",
+            "postcard",
+            "profile",
+            "address-card",
+            "vcard",
+            "address-card-o",
+            "vcard-o"
+        ]
+    },
+    "vcard-o": {
+        "character": "\uf2bb",
+        "searchterms": [
+            "about",
+            "contact",
+            "id",
+            "identification",
+            "postcard",
+            "profile",
+            "address-card",
+            "vcard",
+            "address-card-o",
+            "vcard-o"
+        ]
+    },
+    "vector-square": {
+        "character": "\uf5cb",
+        "searchterms": [
+            "anchors",
+            "lines",
+            "object",
+            "render",
+            "shape",
+            "vector-square"
+        ]
+    },
+    "venus": {
+        "character": "\uf221",
+        "searchterms": [
+            "female",
+            "venus"
+        ]
+    },
+    "venus-double": {
+        "character": "\uf226",
+        "searchterms": [
+            "female",
+            "venus-double"
+        ]
+    },
+    "venus-mars": {
+        "character": "\uf228",
+        "searchterms": [
+            "Gender",
+            "venus-mars"
+        ]
+    },
+    "viacoin": {
+        "character": "\uf237",
+        "searchterms": [
+            "viacoin"
+        ]
+    },
+    "viadeo": {
+        "character": "\uf2a9",
+        "searchterms": [
+            "viadeo"
+        ]
+    },
+    "viadeo-square": {
+        "character": "\uf2aa",
+        "searchterms": [
+            "viadeo-square"
+        ]
+    },
+    "vial": {
+        "character": "\uf492",
+        "searchterms": [
+            "experiment",
+            "lab",
+            "sample",
+            "science",
+            "test",
+            "test tube",
+            "vial"
+        ]
+    },
+    "vials": {
+        "character": "\uf493",
+        "searchterms": [
+            "experiment",
+            "lab",
+            "sample",
+            "science",
+            "test",
+            "test tube",
+            "vials"
+        ]
+    },
+    "viber": {
+        "character": "\uf409",
+        "searchterms": [
+            "viber"
+        ]
+    },
+    "video": {
+        "character": "\uf03d",
+        "searchterms": [
+            "camera",
+            "film",
+            "movie",
+            "record",
+            "video-camera",
+            "video"
+        ]
+    },
+    "video-camera": {
+        "character": "\uf03d",
+        "searchterms": [
+            "camera",
+            "film",
+            "movie",
+            "record",
+            "video-camera",
+            "video"
+        ]
+    },
+    "video-slash": {
+        "character": "\uf4e2",
+        "searchterms": [
+            "add",
+            "create",
+            "film",
+            "new",
+            "positive",
+            "record",
+            "video",
+            "video-slash"
+        ]
+    },
+    "vihara": {
+        "character": "\uf6a7",
+        "searchterms": [
+            "buddhism",
+            "buddhist",
+            "building",
+            "monastery",
+            "vihara"
+        ]
+    },
+    "vimeo": {
+        "character": "\uf40a",
+        "searchterms": [
+            "vimeo"
+        ]
+    },
+    "vimeo-square": {
+        "character": "\uf194",
+        "searchterms": [
+            "vimeo-square"
+        ]
+    },
+    "vimeo-v": {
+        "character": "\uf27d",
+        "searchterms": [
+            "vimeo",
+            "vimeo-v"
+        ]
+    },
+    "vine": {
+        "character": "\uf1ca",
+        "searchterms": [
+            "vine"
+        ]
+    },
+    "vk": {
+        "character": "\uf189",
+        "searchterms": [
+            "vk"
+        ]
+    },
+    "vnv": {
+        "character": "\uf40b",
+        "searchterms": [
+            "vnv"
+        ]
+    },
+    "voicemail": {
+        "character": "\uf897",
+        "searchterms": [
+            "answer",
+            "inbox",
+            "message",
+            "phone",
+            "voicemail"
+        ]
+    },
+    "volleyball-ball": {
+        "character": "\uf45f",
+        "searchterms": [
+            "beach",
+            "olympics",
+            "sport",
+            "volleyball-ball"
+        ]
+    },
+    "volume-control-phone": {
+        "character": "\uf2a0",
+        "searchterms": [
+            "call",
+            "earphone",
+            "number",
+            "sound",
+            "support",
+            "telephone",
+            "voice",
+            "volume-control-phone",
+            "phone-volume"
+        ]
+    },
+    "volume-down": {
+        "character": "\uf027",
+        "searchterms": [
+            "audio",
+            "lower",
+            "music",
+            "quieter",
+            "sound",
+            "speaker",
+            "volume-down"
+        ]
+    },
+    "volume-mute": {
+        "character": "\uf6a9",
+        "searchterms": [
+            "audio",
+            "music",
+            "quiet",
+            "sound",
+            "speaker",
+            "volume-mute"
+        ]
+    },
+    "volume-off": {
+        "character": "\uf026",
+        "searchterms": [
+            "audio",
+            "ban",
+            "music",
+            "mute",
+            "quiet",
+            "silent",
+            "sound",
+            "volume-off"
+        ]
+    },
+    "volume-up": {
+        "character": "\uf028",
+        "searchterms": [
+            "audio",
+            "higher",
+            "louder",
+            "music",
+            "sound",
+            "speaker",
+            "volume-up"
+        ]
+    },
+    "vote-yea": {
+        "character": "\uf772",
+        "searchterms": [
+            "accept",
+            "cast",
+            "election",
+            "politics",
+            "positive",
+            "yes",
+            "vote-yea"
+        ]
+    },
+    "vr-cardboard": {
+        "character": "\uf729",
+        "searchterms": [
+            "3d",
+            "augment",
+            "google",
+            "reality",
+            "virtual",
+            "vr-cardboard"
+        ]
+    },
+    "vuejs": {
+        "character": "\uf41f",
+        "searchterms": [
+            "vuejs"
+        ]
+    },
+    "walking": {
+        "character": "\uf554",
+        "searchterms": [
+            "exercise",
+            "health",
+            "pedometer",
+            "person",
+            "steps",
+            "walking"
+        ]
+    },
+    "wallet": {
+        "character": "\uf555",
+        "searchterms": [
+            "billfold",
+            "cash",
+            "currency",
+            "money",
+            "wallet"
+        ]
+    },
+    "warehouse": {
+        "character": "\uf494",
+        "searchterms": [
+            "building",
+            "capacity",
+            "garage",
+            "inventory",
+            "storage",
+            "warehouse"
+        ]
+    },
+    "warning": {
+        "character": "\uf071",
+        "searchterms": [
+            "alert",
+            "danger",
+            "error",
+            "important",
+            "notice",
+            "notification",
+            "notify",
+            "problem",
+            "warning",
+            "exclamation-triangle"
+        ]
+    },
+    "water": {
+        "character": "\uf773",
+        "searchterms": [
+            "lake",
+            "liquid",
+            "ocean",
+            "sea",
+            "swim",
+            "wet",
+            "water"
+        ]
+    },
+    "wave-square": {
+        "character": "\uf83e",
+        "searchterms": [
+            "frequency",
+            "pulse",
+            "signal",
+            "wave-square"
+        ]
+    },
+    "waze": {
+        "character": "\uf83f",
+        "searchterms": [
+            "waze"
+        ]
+    },
+    "wechat": {
+        "character": "\uf1d7",
+        "searchterms": [
+            "weixin",
+            "wechat"
+        ]
+    },
+    "weebly": {
+        "character": "\uf5cc",
+        "searchterms": [
+            "weebly"
+        ]
+    },
+    "weibo": {
+        "character": "\uf18a",
+        "searchterms": [
+            "weibo"
+        ]
+    },
+    "weight": {
+        "character": "\uf496",
+        "searchterms": [
+            "health",
+            "measurement",
+            "scale",
+            "weight"
+        ]
+    },
+    "weight-hanging": {
+        "character": "\uf5cd",
+        "searchterms": [
+            "anvil",
+            "heavy",
+            "measurement",
+            "weight-hanging"
+        ]
+    },
+    "weixin": {
+        "character": "\uf1d7",
+        "searchterms": [
+            "weixin",
+            "wechat"
+        ]
+    },
+    "whatsapp": {
+        "character": "\uf232",
+        "searchterms": [
+            "whatsapp"
+        ]
+    },
+    "whatsapp-square": {
+        "character": "\uf40c",
+        "searchterms": [
+            "whatsapp-square"
+        ]
+    },
+    "wheelchair": {
+        "character": "\uf193",
+        "searchterms": [
+            "accessible",
+            "handicap",
+            "person",
+            "wheelchair"
+        ]
+    },
+    "wheelchair-alt": {
+        "character": "\uf368",
+        "searchterms": [
+            "accessibility",
+            "handicap",
+            "person",
+            "wheelchair",
+            "wheelchair-alt",
+            "accessible-icon"
+        ]
+    },
+    "whmcs": {
+        "character": "\uf40d",
+        "searchterms": [
+            "whmcs"
+        ]
+    },
+    "wifi": {
+        "character": "\uf1eb",
+        "searchterms": [
+            "connection",
+            "hotspot",
+            "internet",
+            "network",
+            "wireless",
+            "wifi"
+        ]
+    },
+    "wikipedia-w": {
+        "character": "\uf266",
+        "searchterms": [
+            "wikipedia-w"
+        ]
+    },
+    "wind": {
+        "character": "\uf72e",
+        "searchterms": [
+            "air",
+            "blow",
+            "breeze",
+            "fall",
+            "seasonal",
+            "weather",
+            "wind"
+        ]
+    },
+    "window-close": {
+        "character": "\uf410",
+        "searchterms": [
+            "browser",
+            "cancel",
+            "computer",
+            "development",
+            "window-close",
+            "times-rectangle",
+            "window-close-o",
+            "times-rectangle-o"
+        ]
+    },
+    "window-close-o": {
+        "character": "\uf410",
+        "searchterms": [
+            "browser",
+            "cancel",
+            "computer",
+            "development",
+            "window-close",
+            "times-rectangle",
+            "window-close-o",
+            "times-rectangle-o"
+        ]
+    },
+    "window-maximize": {
+        "character": "\uf2d0",
+        "searchterms": [
+            "browser",
+            "computer",
+            "development",
+            "expand",
+            "window-maximize"
+        ]
+    },
+    "window-minimize": {
+        "character": "\uf2d1",
+        "searchterms": [
+            "browser",
+            "collapse",
+            "computer",
+            "development",
+            "window-minimize"
+        ]
+    },
+    "window-restore": {
+        "character": "\uf2d2",
+        "searchterms": [
+            "browser",
+            "computer",
+            "development",
+            "window-restore"
+        ]
+    },
+    "windows": {
+        "character": "\uf17a",
+        "searchterms": [
+            "microsoft",
+            "operating system",
+            "os",
+            "windows"
+        ]
+    },
+    "wine-bottle": {
+        "character": "\uf72f",
+        "searchterms": [
+            "alcohol",
+            "beverage",
+            "cabernet",
+            "drink",
+            "glass",
+            "grapes",
+            "merlot",
+            "sauvignon",
+            "wine-bottle"
+        ]
+    },
+    "wine-glass": {
+        "character": "\uf4e3",
+        "searchterms": [
+            "alcohol",
+            "beverage",
+            "cabernet",
+            "drink",
+            "grapes",
+            "merlot",
+            "sauvignon",
+            "wine-glass"
+        ]
+    },
+    "wine-glass-alt": {
+        "character": "\uf5ce",
+        "searchterms": [
+            "alcohol",
+            "beverage",
+            "cabernet",
+            "drink",
+            "grapes",
+            "merlot",
+            "sauvignon",
+            "wine-glass-alt"
+        ]
+    },
+    "wix": {
+        "character": "\uf5cf",
+        "searchterms": [
+            "wix"
+        ]
+    },
+    "wizards-of-the-coast": {
+        "character": "\uf730",
+        "searchterms": [
+            "Dungeons & Dragons",
+            "d&d",
+            "dnd",
+            "fantasy",
+            "game",
+            "gaming",
+            "tabletop",
+            "wizards-of-the-coast"
+        ]
+    },
+    "wolf-pack-battalion": {
+        "character": "\uf514",
+        "searchterms": [
+            "wolf-pack-battalion"
+        ]
+    },
+    "won": {
+        "character": "\uf159",
+        "searchterms": [
+            "currency",
+            "krw",
+            "money",
+            "won-sign",
+            "won"
+        ]
+    },
+    "won-sign": {
+        "character": "\uf159",
+        "searchterms": [
+            "currency",
+            "krw",
+            "money",
+            "won-sign",
+            "won"
+        ]
+    },
+    "wordpress": {
+        "character": "\uf19a",
+        "searchterms": [
+            "wordpress"
+        ]
+    },
+    "wordpress-simple": {
+        "character": "\uf411",
+        "searchterms": [
+            "wordpress-simple"
+        ]
+    },
+    "wpbeginner": {
+        "character": "\uf297",
+        "searchterms": [
+            "wpbeginner"
+        ]
+    },
+    "wpexplorer": {
+        "character": "\uf2de",
+        "searchterms": [
+            "wpexplorer"
+        ]
+    },
+    "wpforms": {
+        "character": "\uf298",
+        "searchterms": [
+            "wpforms"
+        ]
+    },
+    "wpressr": {
+        "character": "\uf3e4",
+        "searchterms": [
+            "rendact",
+            "wpressr"
+        ]
+    },
+    "wrench": {
+        "character": "\uf0ad",
+        "searchterms": [
+            "construction",
+            "fix",
+            "mechanic",
+            "plumbing",
+            "settings",
+            "spanner",
+            "tool",
+            "update",
+            "wrench"
+        ]
+    },
+    "x-ray": {
+        "character": "\uf497",
+        "searchterms": [
+            "health",
+            "medical",
+            "radiological images",
+            "radiology",
+            "skeleton",
+            "x-ray"
+        ]
+    },
+    "xbox": {
+        "character": "\uf412",
+        "searchterms": [
+            "xbox"
+        ]
+    },
+    "xing": {
+        "character": "\uf168",
+        "searchterms": [
+            "xing"
+        ]
+    },
+    "xing-square": {
+        "character": "\uf169",
+        "searchterms": [
+            "xing-square"
+        ]
+    },
+    "y-combinator": {
+        "character": "\uf23b",
+        "searchterms": [
+            "y-combinator",
+            "yc"
+        ]
+    },
+    "y-combinator-square": {
+        "character": "\uf1d4",
+        "searchterms": [
+            "hacker-news",
+            "y-combinator-square",
+            "yc-square"
+        ]
+    },
+    "yahoo": {
+        "character": "\uf19e",
+        "searchterms": [
+            "yahoo"
+        ]
+    },
+    "yammer": {
+        "character": "\uf840",
+        "searchterms": [
+            "yammer"
+        ]
+    },
+    "yandex": {
+        "character": "\uf413",
+        "searchterms": [
+            "yandex"
+        ]
+    },
+    "yandex-international": {
+        "character": "\uf414",
+        "searchterms": [
+            "yandex-international"
+        ]
+    },
+    "yarn": {
+        "character": "\uf7e3",
+        "searchterms": [
+            "yarn"
+        ]
+    },
+    "yc": {
+        "character": "\uf23b",
+        "searchterms": [
+            "y-combinator",
+            "yc"
+        ]
+    },
+    "yc-square": {
+        "character": "\uf1d4",
+        "searchterms": [
+            "hacker-news",
+            "y-combinator-square",
+            "yc-square"
+        ]
+    },
+    "yelp": {
+        "character": "\uf1e9",
+        "searchterms": [
+            "yelp"
+        ]
+    },
+    "yen": {
+        "character": "\uf157",
+        "searchterms": [
+            "currency",
+            "jpy",
+            "money",
+            "yen-sign",
+            "cny",
+            "rmb",
+            "yen"
+        ]
+    },
+    "yen-sign": {
+        "character": "\uf157",
+        "searchterms": [
+            "currency",
+            "jpy",
+            "money",
+            "yen-sign",
+            "cny",
+            "rmb",
+            "yen"
+        ]
+    },
+    "yin-yang": {
+        "character": "\uf6ad",
+        "searchterms": [
+            "daoism",
+            "opposites",
+            "taoism",
+            "yin-yang"
+        ]
+    },
+    "yoast": {
+        "character": "\uf2b1",
+        "searchterms": [
+            "yoast"
+        ]
+    },
+    "youtube": {
+        "character": "\uf167",
+        "searchterms": [
+            "film",
+            "video",
+            "youtube-play",
+            "youtube-square",
+            "youtube"
+        ]
+    },
+    "youtube-play": {
+        "character": "\uf167",
+        "searchterms": [
+            "film",
+            "video",
+            "youtube-play",
+            "youtube-square",
+            "youtube"
+        ]
+    },
+    "youtube-square": {
+        "character": "\uf431",
+        "searchterms": [
+            "youtube-square"
+        ]
+    },
+    "zhihu": {
+        "character": "\uf63f",
+        "searchterms": [
+            "zhihu"
+        ]
+    }
+}


### PR DESCRIPTION
Hey,

Today I ran into a similar issue as outlined in #45. I needed metadata from Line Awesome to make it better searchable locally, so I wrote a python script that can be found [here] (https://github.com/SirJson/iconmeta2json) that parses the FA icons.json file and a CSS Stylesheet like Line Awesome and tries to match both to extract metadata like search terms.

One big difference at the moment is that I leave out properties like path because they wouldn't match and I needed only the search terms for now. If there is something that could be extracted from the FA icons.json file and needed it should be easy to include as well, I just thought as a starting point having a focus on search is better.

What do you guys think? Is this helpful for you or not a good idea / not needed anymore?